### PR TITLE
Allows "symbol" based lookup

### DIFF
--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -69,6 +69,11 @@ class ParameterResolver
                     continue;
                 }
 
+                if ($this->container->has($parameter->getName())) {
+                    $args[] = $this->container->get($parameter->getName());
+                    continue;
+                }
+
                 throw new DefinitionException(sprintf(
                     "The parameter '%s' of %s has no value defined or guessable",
                     $parameter->getName(),


### PR DESCRIPTION
Basically if you do

$container->set('something', 'some value');

and then you have

__construct($something) {} 

it will obviously not work. This provides a fix for this case.