### PR TITLE
Implementation of #203: string definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
+        "mnapoli/phpunit-easymock": "~0.1.1",
         "ocramius/proxy-manager": "~0.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "container-interop/container-interop": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.4",
         "mnapoli/phpunit-easymock": "~0.1.1",
         "ocramius/proxy-manager": "~0.5"
     },

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -14,6 +14,7 @@ use DI\Definition\Definition;
 use DI\Definition\DefinitionManager;
 use DI\Definition\Resolver\ArrayDefinitionResolver;
 use DI\Definition\Resolver\FunctionCallDefinitionResolver;
+use DI\Definition\Resolver\StringDefinitionResolver;
 use DI\Definition\ValueDefinition;
 use DI\Definition\Helper\DefinitionHelper;
 use DI\Definition\Resolver\AliasDefinitionResolver;
@@ -86,6 +87,7 @@ class Container implements ContainerInteropInterface, ContainerInterface, Factor
             'DI\Definition\ClassDefinition'               => new ClassDefinitionResolver($wrapperContainer, $proxyFactory),
             'DI\Definition\FunctionCallDefinition'        => new FunctionCallDefinitionResolver($wrapperContainer),
             'DI\Definition\EnvironmentVariableDefinition' => new EnvironmentVariableDefinitionResolver($wrapperContainer),
+            'DI\Definition\StringDefinition'              => new StringDefinitionResolver($wrapperContainer),
         );
 
         // Auto-register the container

--- a/src/DI/Definition/Dumper/StringDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/StringDefinitionDumper.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition\Dumper;
+
+use DI\Definition\Definition;
+use DI\Definition\StringDefinition;
+
+/**
+ * Dumps string definitions.
+ *
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class StringDefinitionDumper implements DefinitionDumper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function dump(Definition $definition)
+    {
+        if (! $definition instanceof StringDefinition) {
+            throw new \InvalidArgumentException(sprintf(
+                'This definition dumper is only compatible with StringDefinition objects, %s given',
+                get_class($definition)
+            ));
+        }
+
+        return $definition->getExpression();
+    }
+}

--- a/src/DI/Definition/Helper/StringDefinitionHelper.php
+++ b/src/DI/Definition/Helper/StringDefinitionHelper.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition\Helper;
+
+use DI\Definition\StringDefinition;
+
+/**
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class StringDefinitionHelper implements DefinitionHelper
+{
+    /**
+     * @var string
+     */
+    private $expression;
+
+    public function __construct($expression)
+    {
+        $this->expression = $expression;
+    }
+
+    /**
+     * @param string $entryName Container entry name
+     *
+     * @return StringDefinition
+     */
+    public function getDefinition($entryName)
+    {
+        return new StringDefinition($entryName, $this->expression);
+    }
+}

--- a/src/DI/Definition/Resolver/StringDefinitionResolver.php
+++ b/src/DI/Definition/Resolver/StringDefinitionResolver.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://mnapoli.github.com/PHP-DI/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition\Resolver;
+
+use DI\Definition\Definition;
+use DI\Definition\StringDefinition;
+use DI\DependencyException;
+use DI\NotFoundException;
+use Interop\Container\ContainerInterface;
+
+/**
+ * Resolves a string expression.
+ *
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class StringDefinitionResolver implements DefinitionResolver
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * The resolver needs a container.
+     * This container will be used to get the entry to which the alias points to.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Resolve a value definition to a value.
+     *
+     * A value definition is simple, so this will just return the value of the ValueDefinition.
+     *
+     * @param StringDefinition $definition
+     *
+     * {@inheritdoc}
+     */
+    public function resolve(Definition $definition, array $parameters = array())
+    {
+        $this->assertIsStringDefinition($definition);
+
+        $expression = $definition->getExpression();
+
+        // TODO Remove PHP 5.3 support
+        $container = $this->container;
+
+        $result = preg_replace_callback('#\{([^\{\}]+)\}#', function (array $matches) use ($container, $definition) {
+            try {
+                return $container->get($matches[1]);
+            } catch (NotFoundException $e) {
+                throw new DependencyException(sprintf(
+                    "Error while parsing string expression for entry %s: %s",
+                    $definition->getName(),
+                    $e->getMessage()
+                ), 0, $e);
+            }
+        }, $expression);
+
+        if ($result === null) {
+            throw new \RuntimeException(sprintf('An unknown error occurred while parsing the string definition: \'%s\'', $expression));
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isResolvable(Definition $definition, array $parameters = array())
+    {
+        $this->assertIsStringDefinition($definition);
+
+        return true;
+    }
+
+    private function assertIsStringDefinition(Definition $definition)
+    {
+        if (!$definition instanceof StringDefinition) {
+            throw new \InvalidArgumentException(sprintf(
+                'This definition resolver is only compatible with StringDefinition objects, %s given',
+                get_class($definition)
+            ));
+        }
+    }
+}

--- a/src/DI/Definition/StringDefinition.php
+++ b/src/DI/Definition/StringDefinition.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition;
+
+use DI\Scope;
+
+/**
+ * Definition of a string composed of other strings.
+ *
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class StringDefinition implements Definition
+{
+    /**
+     * Entry name
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $expression;
+
+    /**
+     * @param string $name       Entry name
+     * @param string $expression
+     */
+    public function __construct($name, $expression)
+    {
+        $this->name = $name;
+        $this->expression = $expression;
+    }
+
+    /**
+     * @return string Entry name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScope()
+    {
+        return Scope::SINGLETON();
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpression()
+    {
+        return $this->expression;
+    }
+}

--- a/src/DI/functions.php
+++ b/src/DI/functions.php
@@ -14,6 +14,7 @@ use DI\Definition\Helper\ArrayDefinitionExtensionHelper;
 use DI\Definition\Helper\FactoryDefinitionHelper;
 use DI\Definition\Helper\ClassDefinitionHelper;
 use DI\Definition\Helper\EnvironmentVariableDefinitionHelper;
+use DI\Definition\Helper\StringDefinitionHelper;
 
 if (! function_exists('DI\object')) {
     /**
@@ -104,5 +105,25 @@ if (! function_exists('DI\add')) {
         }
 
         return new ArrayDefinitionExtensionHelper($values);
+    }
+}
+
+if (! function_exists('DI\string')) {
+    /**
+     * Helper for concatenating strings.
+     *
+     * Example:
+     *
+     *     'log.filename' => DI\string('{app.path}/app.log')
+     *
+     * @param string $expression A string expression. Use the `{}` placeholders to reference other container entries.
+     *
+     * @return StringDefinitionHelper
+     *
+     * @since 5.0
+     */
+    function string($expression)
+    {
+        return new StringDefinitionHelper((string) $expression);
     }
 }

--- a/tests/IntegrationTest/Fixtures/definitions.php
+++ b/tests/IntegrationTest/Fixtures/definitions.php
@@ -4,6 +4,7 @@ use DI\Scope;
 
 return array(
     'foo' => 'bar',
+    'test-string' => DI\string('Hello {foo}'),
 
     'DI\Test\IntegrationTest\Fixtures\Class1' => DI\object()
             ->scope(Scope::PROTOTYPE())

--- a/tests/IntegrationTest/StringDefinitionTest.php
+++ b/tests/IntegrationTest/StringDefinitionTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\IntegrationTest;
+
+use DI\Container;
+use DI\ContainerBuilder;
+
+/**
+ * Test string definitions
+ *
+ * @coversNothing
+ */
+class StringDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(__DIR__ . '/Fixtures/definitions.php');
+
+        $this->container = $builder->build();
+    }
+
+    public function test_string_definition()
+    {
+        $this->assertEquals('Hello bar', $this->container->get('test-string'));
+    }
+}

--- a/tests/UnitTest/Definition/Dumper/StringDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/StringDefinitionDumperTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition\Dumper;
+
+use DI\Definition\Dumper\StringDefinitionDumper;
+use DI\Definition\StringDefinition;
+use DI\Definition\ValueDefinition;
+
+/**
+ * @covers \DI\Definition\Dumper\StringDefinitionDumper
+ */
+class StringDefinitionDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDump()
+    {
+        $dumper = new StringDefinitionDumper();
+
+        $this->assertEquals('foo/{bar}', $dumper->dump(new StringDefinition('foo', 'foo/{bar}')));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage This definition dumper is only compatible with StringDefinition objects, DI\Definition\ValueDefinition given
+     */
+    public function testInvalidDefinitionType()
+    {
+        $definition = new ValueDefinition('foo', 'bar');
+        $dumper = new StringDefinitionDumper();
+
+        $dumper->dump($definition);
+    }
+}

--- a/tests/UnitTest/Definition/Helper/StringDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/StringDefinitionHelperTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition\Helper;
+
+use DI\Definition\Helper\StringDefinitionHelper;
+use DI\Definition\StringDefinition;
+
+/**
+ * @covers \DI\Definition\Helper\StringDefinitionHelper
+ */
+class StringDefinitionHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function test_string_definition_helper()
+    {
+        $helper = new StringDefinitionHelper('hello');
+
+        $definition = $helper->getDefinition('foo');
+
+        $this->assertTrue($definition instanceof StringDefinition);
+        $this->assertSame('foo', $definition->getName());
+        $this->assertSame('hello', $definition->getExpression());
+    }
+}

--- a/tests/UnitTest/Definition/Resolver/StringDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/StringDefinitionResolverTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition\Resolver;
+
+use DI\Definition\FactoryDefinition;
+use DI\Definition\Resolver\StringDefinitionResolver;
+use DI\Definition\StringDefinition;
+use DI\NotFoundException;
+use EasyMock\EasyMock;
+
+/**
+ * @covers \DI\Definition\Resolver\StringDefinitionResolver
+ */
+class StringDefinitionResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_resolve_bare_strings()
+    {
+        $container = EasyMock::mock('Interop\Container\ContainerInterface');
+
+        $definition = new StringDefinition('foo', 'bar');
+        $resolver = new StringDefinitionResolver($container);
+
+        $value = $resolver->resolve($definition);
+
+        $this->assertEquals('bar', $value);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_resolve_references()
+    {
+        $container = EasyMock::mock('Interop\Container\ContainerInterface', array(
+            'get' => 'bar',
+        ));
+
+        $definition = new StringDefinition('foo', '{test}');
+        $resolver = new StringDefinitionResolver($container);
+
+        $value = $resolver->resolve($definition);
+
+        $this->assertEquals('bar', $value);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_resolve_multiple_references()
+    {
+        $container = EasyMock::mock('Interop\Container\ContainerInterface');
+        $container->expects($this->exactly(2))
+            ->method('get')
+            ->withConsecutive(array('tmp'), array('logs'))
+            ->willReturnOnConsecutiveCalls('/private/tmp', 'myapp-logs');
+
+        $definition = new StringDefinition('foo', '{tmp}/{logs}/app.log');
+        $resolver = new StringDefinitionResolver($container);
+
+        $value = $resolver->resolve($definition);
+
+        $this->assertEquals('/private/tmp/myapp-logs/app.log', $value);
+    }
+
+    /**
+     * @test
+     * @expectedException \DI\DependencyException
+     * @expectedExceptionMessage Error while parsing string expression for entry foo: No entry or class found for 'test'
+     */
+    public function it_should_throw_on_unknown_entry_name()
+    {
+        $container = EasyMock::mock('Interop\Container\ContainerInterface', array(
+            'get' => new NotFoundException("No entry or class found for 'test'"),
+        ));
+
+        $definition = new StringDefinition('foo', '{test}');
+        $resolver = new StringDefinitionResolver($container);
+
+        $resolver->resolve($definition);
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage This definition resolver is only compatible with StringDefinition objects, DI\Definition\FactoryDefinition given
+     */
+    public function it_should_error_with_unsupported_definitions()
+    {
+        $container = EasyMock::mock('Interop\Container\ContainerInterface');
+        $definition = new FactoryDefinition('foo', function () {
+        });
+        $resolver = new StringDefinitionResolver($container);
+
+        $resolver->resolve($definition);
+    }
+}

--- a/tests/UnitTest/Definition/StringDefinitionTest.php
+++ b/tests/UnitTest/Definition/StringDefinitionTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition;
+
+use DI\Definition\StringDefinition;
+use DI\Scope;
+
+/**
+ * @covers \DI\Definition\StringDefinition
+ */
+class StringDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        $definition = new StringDefinition('foo', 'bar');
+
+        $this->assertEquals('foo', $definition->getName());
+        $this->assertEquals('bar', $definition->getExpression());
+    }
+
+    public function testScope()
+    {
+        $definition = new StringDefinition('foo', 'bar');
+
+        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+    }
+
+    public function testCacheable()
+    {
+        $this->assertNotInstanceOf('DI\Definition\CacheableDefinition', new StringDefinition('foo', 'bar'));
+    }
+}

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -88,4 +88,20 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $definition->getExtendedDefinitionName());
         $this->assertEquals(array('hello', 'world'), $definition->getValues());
     }
+
+    /**
+     * @covers ::\DI\string
+     */
+    public function test_string()
+    {
+        $helper = \DI\string('bar');
+
+        $this->assertInstanceOf('DI\Definition\Helper\StringDefinitionHelper', $helper);
+
+        $definition = $helper->getDefinition('foo');
+
+        $this->assertInstanceOf('DI\Definition\StringDefinition', $definition);
+        $this->assertEquals('foo', $definition->getName());
+        $this->assertEquals('bar', $definition->getExpression());
+    }
 }


### PR DESCRIPTION
See #203

Example:

```php
return [
    'path.application' => realpath(__DIR__ . '/..'),
    'path.tmp' => DI\string('{path.application}/tmp'),
    'log.file' => DI\string('{path.tmp}/app.log'),
];
```