### PR TITLE
Add support for nested definitions

### DIFF
--- a/src/DI/Definition/Resolver/AliasDefinitionResolver.php
+++ b/src/DI/Definition/Resolver/AliasDefinitionResolver.php
@@ -54,13 +54,15 @@ class AliasDefinitionResolver implements DefinitionResolver
     }
 
     /**
+     * @param AliasDefinition $definition
+     *
      * {@inheritdoc}
      */
     public function isResolvable(Definition $definition, array $parameters = array())
     {
         $this->assertIsAliasDefinition($definition);
 
-        return true;
+        return $this->container->has($definition->getTargetEntryName());
     }
 
     /**

--- a/src/DI/Definition/Resolver/EnvironmentVariableDefinitionResolver.php
+++ b/src/DI/Definition/Resolver/EnvironmentVariableDefinitionResolver.php
@@ -10,10 +10,9 @@
 namespace DI\Definition\Resolver;
 
 use DI\Definition\Definition;
-use DI\Definition\EntryReference;
 use DI\Definition\EnvironmentVariableDefinition;
 use DI\Definition\Exception\DefinitionException;
-use Interop\Container\ContainerInterface;
+use DI\Definition\Helper\DefinitionHelper;
 
 /**
  * Resolves a environment variable definition to a value.
@@ -23,18 +22,18 @@ use Interop\Container\ContainerInterface;
 class EnvironmentVariableDefinitionResolver implements DefinitionResolver
 {
     /**
-     * @var ContainerInterface
+     * @var DefinitionResolver
      */
-    private $container;
+    private $definitionResolver;
 
     /**
      * @var callable
      */
     private $variableReader;
 
-    public function __construct(ContainerInterface $container, $variableReader = 'getenv')
+    public function __construct(DefinitionResolver $definitionResolver, $variableReader = 'getenv')
     {
-        $this->container = $container;
+        $this->definitionResolver = $definitionResolver;
         $this->variableReader = $variableReader;
     }
 
@@ -62,8 +61,9 @@ class EnvironmentVariableDefinitionResolver implements DefinitionResolver
 
         $value = $definition->getDefaultValue();
 
-        if ($value instanceof EntryReference) {
-            return $this->container->get($value->getName());
+        // Nested definition
+        if ($value instanceof DefinitionHelper) {
+            return $this->definitionResolver->resolve($value->getDefinition(''));
         }
 
         return $value;

--- a/src/DI/Definition/Resolver/FunctionCallDefinitionResolver.php
+++ b/src/DI/Definition/Resolver/FunctionCallDefinitionResolver.php
@@ -34,14 +34,13 @@ class FunctionCallDefinitionResolver implements DefinitionResolver
     private $parameterResolver;
 
     /**
-     * The resolver needs a container. This container will be used to fetch dependencies.
-     *
-     * @param ContainerInterface $container
+     * @param ContainerInterface $container Used to fetch dependencies.
+     * @param DefinitionResolver $definitionResolver Used to resolve nested definitions.
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, DefinitionResolver $definitionResolver)
     {
         $this->container = $container;
-        $this->parameterResolver = new ParameterResolver($container);
+        $this->parameterResolver = new ParameterResolver($definitionResolver);
     }
 
     /**

--- a/src/DI/Definition/Resolver/ParameterResolver.php
+++ b/src/DI/Definition/Resolver/ParameterResolver.php
@@ -11,9 +11,8 @@ namespace DI\Definition\Resolver;
 
 use DI\Definition\AbstractFunctionCallDefinition;
 use DI\Definition\ClassDefinition;
-use DI\Definition\EntryReference;
 use DI\Definition\Exception\DefinitionException;
-use Interop\Container\ContainerInterface;
+use DI\Definition\Helper\DefinitionHelper;
 
 /**
  * Resolves parameters for a function call.
@@ -24,16 +23,16 @@ use Interop\Container\ContainerInterface;
 class ParameterResolver
 {
     /**
-     * @var ContainerInterface
+     * @var DefinitionResolver
      */
-    private $container;
+    private $definitionResolver;
 
     /**
-     * @param ContainerInterface $container Will be used to fetch dependencies.
+     * @param DefinitionResolver $definitionResolver Will be used to resolve nested definitions.
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(DefinitionResolver $definitionResolver)
     {
-        $this->container = $container;
+        $this->definitionResolver = $definitionResolver;
     }
 
     /**
@@ -76,12 +75,14 @@ class ParameterResolver
                 ));
             }
 
-            if ($value instanceof EntryReference) {
+            if ($value instanceof DefinitionHelper) {
+                $nestedDefinition = $value->getDefinition('');
+
                 // If the container cannot produce the entry, we can use the default parameter value
-                if (!$this->container->has($value->getName()) && $parameter->isOptional()) {
+                if (!$this->definitionResolver->isResolvable($nestedDefinition) && $parameter->isOptional()) {
                     $value = $this->getParameterDefaultValue($parameter, $functionReflection);
                 } else {
-                    $value = $this->container->get($value->getName());
+                    $value = $this->definitionResolver->resolve($nestedDefinition);
                 }
             }
 
@@ -89,14 +90,6 @@ class ParameterResolver
         }
 
         return $args;
-    }
-
-    /**
-     * @return ContainerInterface
-     */
-    public function getContainer()
-    {
-        return $this->container;
     }
 
     /**

--- a/src/DI/Definition/Resolver/ResolverDispatcher.php
+++ b/src/DI/Definition/Resolver/ResolverDispatcher.php
@@ -22,7 +22,7 @@ class ResolverDispatcher implements DefinitionResolver
      */
     private $definitionResolvers;
 
-    public function __construct(array $definitionResolvers)
+    public function __construct(array $definitionResolvers = array())
     {
         $this->definitionResolvers = $definitionResolvers;
     }
@@ -38,20 +38,24 @@ class ResolverDispatcher implements DefinitionResolver
     {
         $arrayDefinitionResolver = new ArrayDefinitionResolver($container);
 
+        $resolver = new self();
+
         $definitionResolvers = array(
             'DI\Definition\ValueDefinition'               => new ValueDefinitionResolver(),
             'DI\Definition\ArrayDefinition'               => $arrayDefinitionResolver,
             'DI\Definition\ArrayDefinitionExtension'      => $arrayDefinitionResolver,
             'DI\Definition\FactoryDefinition'             => new FactoryDefinitionResolver($container),
             'DI\Definition\AliasDefinition'               => new AliasDefinitionResolver($container),
-            'DI\Definition\ClassDefinition'               => new ClassDefinitionResolver($container, $proxyFactory),
-            'DI\Definition\InstanceDefinition'            => new InstanceDefinitionResolver($container, $proxyFactory),
-            'DI\Definition\FunctionCallDefinition'        => new FunctionCallDefinitionResolver($container),
-            'DI\Definition\EnvironmentVariableDefinition' => new EnvironmentVariableDefinitionResolver($container),
+            'DI\Definition\ClassDefinition'               => new ClassDefinitionResolver($resolver, $proxyFactory),
+            'DI\Definition\InstanceDefinition'            => new InstanceDefinitionResolver($resolver, $proxyFactory),
+            'DI\Definition\FunctionCallDefinition'        => new FunctionCallDefinitionResolver($container, $resolver),
+            'DI\Definition\EnvironmentVariableDefinition' => new EnvironmentVariableDefinitionResolver($resolver),
             'DI\Definition\StringDefinition'              => new StringDefinitionResolver($container),
         );
 
-        return new self($definitionResolvers);
+        $resolver->setDefinitionResolvers($definitionResolvers);
+
+        return $resolver;
     }
 
     /**
@@ -103,5 +107,13 @@ class ResolverDispatcher implements DefinitionResolver
         }
 
         return $this->definitionResolvers[$definitionType];
+    }
+
+    /**
+     * @param DefinitionResolver[] $definitionResolvers
+     */
+    public function setDefinitionResolvers(array $definitionResolvers)
+    {
+        $this->definitionResolvers = $definitionResolvers;
     }
 }

--- a/tests/IntegrationTest/BuggyInjectionsTest.php
+++ b/tests/IntegrationTest/BuggyInjectionsTest.php
@@ -40,7 +40,7 @@ class BuggyInjectionsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \DI\DependencyException
-     * @expectedExceptionMessage Error while injecting 'namedDependency' in DI\Test\IntegrationTest\Fixtures\SetterInjectionTest\NamedInjectionClass::dependency. No entry or class found for 'namedDependency'
+     * @expectedExceptionMessage Error while injecting in DI\Test\IntegrationTest\Fixtures\SetterInjectionTest\NamedInjectionClass::dependency. No entry or class found for 'namedDependency'
      */
     public function testSetterNamedInjectionNotFound()
     {
@@ -71,7 +71,7 @@ class BuggyInjectionsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \DI\DependencyException
-     * @expectedExceptionMessage Error while injecting 'db.host' in DI\Test\IntegrationTest\Fixtures\ValueInjectionTest\ValueInjectionClass::value. No entry or class found for 'db.host'
+     * @expectedExceptionMessage Error while injecting in DI\Test\IntegrationTest\Fixtures\ValueInjectionTest\ValueInjectionClass::value. No entry or class found for 'db.host'
      */
     public function testValueException()
     {

--- a/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\IntegrationTest\Definitions;
+
+use DI\ContainerBuilder;
+use DI\Test\IntegrationTest\Fixtures\Class1;
+use DI\Test\IntegrationTest\Fixtures\Implementation1;
+use DI\Test\IntegrationTest\Fixtures\LazyDependency;
+
+/**
+ * @coversNothing
+ */
+class NestedDefinitionsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function should_allow_nested_definitions_in_environment_variables()
+    {
+        $builder = new ContainerBuilder();
+
+        $builder->addDefinitions(array(
+            'foo'    => 'bar',
+            'link'   => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\link('foo')),
+            'object' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\object('stdClass')),
+        ));
+
+        $container = $builder->build();
+
+        $this->assertEquals('bar', $container->get('link'));
+        $this->assertEquals(new \stdClass(), $container->get('object'));
+    }
+
+    /**
+     * @test
+     */
+    public function should_allow_nested_definitions_in_object_definitions()
+    {
+        $builder = new ContainerBuilder();
+        $builder->useAnnotations(false);
+
+        $impl = new Implementation1();
+        $lazyDep = new LazyDependency();
+
+        $builder->addDefinitions(array(
+            'foo' => 'bar',
+            'DI\Test\IntegrationTest\Fixtures\LazyDependency' => $lazyDep,
+            'obj' => \DI\object('DI\Test\IntegrationTest\Fixtures\Class1')
+                ->constructor(
+                    \DI\object('DI\Test\IntegrationTest\Fixtures\Class2'),
+                    \DI\factory(function () use ($impl) {
+                        return $impl;
+                    })
+                )
+                ->property('property1', \DI\link('foo'))
+                ->property('property2', \DI\factory(function () use ($impl) {
+                    return $impl;
+                })),
+        ));
+
+        $container = $builder->build();
+        /** @var Class1 $obj */
+        $obj = $container->get('obj');
+
+        // Assertions on constructor parameters
+        $this->assertInstanceOf('DI\Test\IntegrationTest\Fixtures\Class2', $obj->constructorParam1);
+        $this->assertSame($impl, $obj->constructorParam2);
+        $this->assertSame($lazyDep, $obj->constructorParam3);
+
+        // Assertions on properties
+        $this->assertEquals('bar', $obj->property1);
+        $this->assertSame($impl, $obj->property2);
+    }
+}

--- a/tests/UnitTest/Definition/Resolver/ClassDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ClassDefinitionResolverTest.php
@@ -13,9 +13,11 @@ use DI\Definition\FactoryDefinition;
 use DI\Definition\ClassDefinition;
 use DI\Definition\ClassDefinition\MethodInjection;
 use DI\Definition\ClassDefinition\PropertyInjection;
-use DI\Definition\EntryReference;
 use DI\Definition\Resolver\ClassDefinitionResolver;
+use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Proxy\ProxyFactory;
+use EasyMock\EasyMock;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \DI\Definition\Resolver\ClassDefinitionResolver
@@ -28,15 +30,37 @@ class ClassDefinitionResolverTest extends \PHPUnit_Framework_TestCase
     const FIXTURE_INTERFACE = 'DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureInterface';
     const FIXTURE_ABSTRACT_CLASS = 'DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureAbstractClass';
 
+    /**
+     * @var ProxyFactory|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $proxyFactory;
+
+    /**
+     * @var ResolverDispatcher|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resolverDispatcher;
+
+    /**
+     * @var ClassDefinitionResolver
+     */
+    private $resolver;
+
+    public function setUp()
+    {
+        $this->proxyFactory = EasyMock::mock('DI\Proxy\ProxyFactory');
+        $this->resolverDispatcher = EasyMock::mock('DI\Definition\Resolver\ResolverDispatcher');
+
+        $this->resolver = new ClassDefinitionResolver($this->resolverDispatcher, $this->proxyFactory);
+    }
+
     public function testResolve()
     {
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
         $definition->addPropertyInjection(new PropertyInjection('prop', 'value1'));
         $definition->setConstructorInjection(MethodInjection::constructor(array('value2')));
         $definition->addMethodInjection(new MethodInjection('method', array('value3')));
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition);
+        $object = $this->resolver->resolve($definition);
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertEquals('value1', $object->prop);
@@ -47,18 +71,16 @@ class ClassDefinitionResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolveNoConstructorClass()
     {
         $definition = new ClassDefinition(self::FIXTURE_CLASS_NO_CONSTRUCTOR);
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition);
+        $object = $this->resolver->resolve($definition);
         $this->assertInstanceOf(self::FIXTURE_CLASS_NO_CONSTRUCTOR, $object);
     }
 
     public function testResolveWithParameters()
     {
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition, array('param1' => 'value'));
+        $object = $this->resolver->resolve($definition, array('param1' => 'value'));
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertEquals('value', $object->constructorParam1);
@@ -71,9 +93,8 @@ class ClassDefinitionResolverTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
         $definition->setConstructorInjection(MethodInjection::constructor(array('foo')));
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition, array('param1' => 'bar'));
+        $object = $this->resolver->resolve($definition, array('param1' => 'bar'));
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertEquals('bar', $object->constructorParam1);
@@ -85,37 +106,54 @@ class ClassDefinitionResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolveWithUselessParameters()
     {
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition, array('param1' => 'value', 'unknown' => 'foo'));
+        $object = $this->resolver->resolve($definition, array('param1' => 'value', 'unknown' => 'foo'));
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertEquals('value', $object->constructorParam1);
     }
 
     /**
-     * Check that entry references (in the definition) are resolved using the container
+     * Check that nested definitions are resolved in parameters
      */
-    public function testResolveWithEntryReference()
+    public function testResolveWithNestedDefinitionInParameters()
     {
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
-        // The constructor definition uses an EntryReference
-        $definition->setConstructorInjection(MethodInjection::constructor(array(new EntryReference('foo'))));
+        // The constructor definition uses a nested definition
+        $definition->setConstructorInjection(MethodInjection::constructor(array(
+            \DI\object(self::FIXTURE_CLASS_NO_CONSTRUCTOR),
+        )));
 
-        $container = $this->getMock('DI\Container', array(), array(), '', false);
-        $container->expects($this->once())
-            ->method('get')
-            ->with('foo')
+        $this->resolverDispatcher->expects($this->once())
+            ->method('resolve')
+            ->with($this->isInstanceOf('DI\Definition\ClassDefinition'))
             ->will($this->returnValue('bar'));
-        /** @var ProxyFactory $factory */
-        $factory = $this->getMock('DI\Proxy\ProxyFactory', array(), array(), '', false);
 
-        $resolver = new ClassDefinitionResolver($container, $factory);
-
-        $object = $resolver->resolve($definition);
+        $object = $this->resolver->resolve($definition);
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertEquals('bar', $object->constructorParam1);
+    }
+
+    /**
+     * Check that nested definitions are resolved in properties
+     */
+    public function testResolveWithNestedDefinitionInProperties()
+    {
+        $definition = new ClassDefinition(self::FIXTURE_CLASS);
+        $definition->addPropertyInjection(new PropertyInjection('prop', \DI\object(self::FIXTURE_CLASS_NO_CONSTRUCTOR)));
+        // Unrelated to the test but necessary since it's a mandatory parameter
+        $definition->setConstructorInjection(MethodInjection::constructor(array('foo')));
+
+        $this->resolverDispatcher->expects($this->once())
+            ->method('resolve')
+            ->with($this->isInstanceOf('DI\Definition\ClassDefinition'))
+            ->will($this->returnValue('bar'));
+
+        $object = $this->resolver->resolve($definition);
+
+        $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
+        $this->assertEquals('bar', $object->prop);
     }
 
     /**
@@ -126,9 +164,8 @@ class ClassDefinitionResolverTest extends \PHPUnit_Framework_TestCase
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
         $definition->setConstructorInjection(MethodInjection::constructor(array(null)));
         $definition->addPropertyInjection(new PropertyInjection('prop', null));
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition);
+        $object = $this->resolver->resolve($definition);
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertNull($object->constructorParam1);
@@ -140,24 +177,11 @@ class ClassDefinitionResolverTest extends \PHPUnit_Framework_TestCase
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
         $definition->setConstructorInjection(MethodInjection::constructor(array('')));
         $definition->addMethodInjection(new MethodInjection('methodDefaultValue'));
-        $resolver = $this->buildResolver();
 
-        $object = $resolver->resolve($definition);
+        $object = $this->resolver->resolve($definition);
 
         $this->assertInstanceOf(self::FIXTURE_CLASS, $object);
         $this->assertEquals('defaultValue', $object->methodParam2);
-    }
-
-    public function testGetContainer()
-    {
-        /** @var \DI\Container $container */
-        $container = $this->getMock('DI\Container', array(), array(), '', false);
-        /** @var ProxyFactory $factory */
-        $factory = $this->getMock('DI\Proxy\ProxyFactory', array(), array(), '', false);
-
-        $resolver = new ClassDefinitionResolver($container, $factory);
-
-        $this->assertSame($container, $resolver->getContainer());
     }
 
     public function testUnknownClass()
@@ -174,9 +198,8 @@ MESSAGE;
         $this->setExpectedException('DI\Definition\Exception\DefinitionException', $message);
 
         $definition = new ClassDefinition('foo', 'bar');
-        $resolver = $this->buildResolver();
 
-        $resolver->resolve($definition);
+        $this->resolver->resolve($definition);
     }
 
     public function testNotInstantiable()
@@ -193,9 +216,8 @@ MESSAGE;
         $this->setExpectedException('DI\Definition\Exception\DefinitionException', $message);
 
         $definition = new ClassDefinition('ArrayAccess');
-        $resolver = $this->buildResolver();
 
-        $resolver->resolve($definition);
+        $this->resolver->resolve($definition);
     }
 
     public function testUndefinedInjection()
@@ -212,9 +234,8 @@ MESSAGE;
         $this->setExpectedException('DI\Definition\Exception\DefinitionException', $message);
 
         $definition = new ClassDefinition(self::FIXTURE_CLASS);
-        $resolver = $this->buildResolver();
 
-        $resolver->resolve($definition);
+        $this->resolver->resolve($definition);
     }
 
     /**
@@ -223,39 +244,21 @@ MESSAGE;
      */
     public function testInvalidDefinitionType()
     {
-        /** @var \DI\Container $container */
-        $container = $this->getMock('DI\Container', array(), array(), '', false);
-        /** @var ProxyFactory $factory */
-        $factory = $this->getMock('DI\Proxy\ProxyFactory', array(), array(), '', false);
-
         $definition = new FactoryDefinition('foo', function () {
         });
-        $resolver = new ClassDefinitionResolver($container, $factory);
 
-        $resolver->resolve($definition);
+        $this->resolver->resolve($definition);
     }
 
     public function testIsResolvable()
     {
-        $resolver = $this->buildResolver();
-
         $classDefinition = new ClassDefinition(self::FIXTURE_CLASS);
-        $this->assertTrue($resolver->isResolvable($classDefinition));
+        $this->assertTrue($this->resolver->isResolvable($classDefinition));
 
         $interfaceDefinition = new ClassDefinition(self::FIXTURE_INTERFACE);
-        $this->assertFalse($resolver->isResolvable($interfaceDefinition));
+        $this->assertFalse($this->resolver->isResolvable($interfaceDefinition));
 
         $abstractClassDefinition = new ClassDefinition(self::FIXTURE_ABSTRACT_CLASS);
-        $this->assertFalse($resolver->isResolvable($abstractClassDefinition));
-    }
-
-    private function buildResolver()
-    {
-        /** @var \DI\Container $container */
-        $container = $this->getMock('DI\Container', array(), array(), '', false);
-        /** @var ProxyFactory $factory */
-        $factory = $this->getMock('DI\Proxy\ProxyFactory', array(), array(), '', false);
-
-        return new ClassDefinitionResolver($container, $factory);
+        $this->assertFalse($this->resolver->isResolvable($abstractClassDefinition));
     }
 }

--- a/tests/UnitTest/Definition/Resolver/EnvironmentVariableDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/EnvironmentVariableDefinitionResolverTest.php
@@ -9,19 +9,28 @@
 
 namespace DI\Test\UnitTest\Definition\Resolver;
 
+use DI\Definition\AliasDefinition;
 use DI\Definition\EntryReference;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\EnvironmentVariableDefinition;
+use DI\Definition\Resolver\DefinitionResolver;
 use DI\Definition\Resolver\EnvironmentVariableDefinitionResolver;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \DI\Definition\Resolver\EnvironmentVariableDefinitionResolver
  */
 class EnvironmentVariableDefinitionResolverTest extends \PHPUnit_Framework_TestCase
 {
-    private $container;
-    private $variableReader;
+    /**
+     * @var EnvironmentVariableDefinitionResolver
+     */
     private $resolver;
+    /**
+     * @var DefinitionResolver|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $parentResolver;
+    private $variableReader;
     private $definedDefinition;
     private $undefinedDefinition;
     private $optionalDefinition;
@@ -30,7 +39,7 @@ class EnvironmentVariableDefinitionResolverTest extends \PHPUnit_Framework_TestC
 
     public function setUp()
     {
-        $this->container = $this->getMock('Interop\Container\ContainerInterface');
+        $this->parentResolver = $this->getMock('DI\Definition\Resolver\DefinitionResolver');
 
         $this->variableReader = function ($variableName) {
             if ('DEFINED' === $variableName) {
@@ -40,11 +49,11 @@ class EnvironmentVariableDefinitionResolverTest extends \PHPUnit_Framework_TestC
             return false;
         };
 
-        $this->resolver = new EnvironmentVariableDefinitionResolver($this->container, $this->variableReader);
+        $this->resolver = new EnvironmentVariableDefinitionResolver($this->parentResolver, $this->variableReader);
         $this->definedDefinition = new EnvironmentVariableDefinition('foo', 'DEFINED');
         $this->undefinedDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED');
         $this->optionalDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED', true, '<default>');
-        $this->linkedDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED', true, new EntryReference('foo'));
+        $this->linkedDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED', true, \DI\link('foo'));
         $this->invalidDefinition = new FactoryDefinition('foo', function () {});
     }
 
@@ -64,9 +73,9 @@ class EnvironmentVariableDefinitionResolverTest extends \PHPUnit_Framework_TestC
 
     public function testResolveWithLinkedDefault()
     {
-        $this->container->expects($this->once())
-            ->method('get')
-            ->with('foo')
+        $this->parentResolver->expects($this->once())
+            ->method('resolve')
+            ->with(new AliasDefinition('', 'foo'))
             ->will($this->returnValue('bar'));
 
         $value = $this->resolver->resolve($this->linkedDefinition);

--- a/tests/UnitTest/Definition/Resolver/FunctionCallDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FunctionCallDefinitionResolverTest.php
@@ -11,6 +11,7 @@ namespace DI\Test\UnitTest\Definition\Resolver;
 
 use DI\Container;
 use DI\Definition\FunctionCallDefinition;
+use DI\Definition\Resolver\AliasDefinitionResolver;
 use DI\Definition\Resolver\FunctionCallDefinitionResolver;
 use DI\Definition\ValueDefinition;
 
@@ -160,7 +161,7 @@ class FunctionCallDefinitionResolverTest extends \PHPUnit_Framework_TestCase
 
     private function assert_definition_resolver(Container $container)
     {
-        return new FunctionCallDefinitionResolver($container);
+        return new FunctionCallDefinitionResolver($container, new AliasDefinitionResolver($container));
     }
 
     private function assert_container_get(\PHPUnit_Framework_MockObject_MockObject $container, $id, $returnedValue)

--- a/tests/UnitTest/Definition/Resolver/InstanceDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/InstanceDefinitionResolverTest.php
@@ -14,6 +14,7 @@ use DI\Definition\ClassDefinition\MethodInjection;
 use DI\Definition\ClassDefinition\PropertyInjection;
 use DI\Definition\InstanceDefinition;
 use DI\Definition\Resolver\InstanceDefinitionResolver;
+use DI\Definition\Resolver\ResolverDispatcher;
 use DI\Proxy\ProxyFactory;
 use DI\Test\UnitTest\Definition\Resolver\Fixture\FixtureClass;
 use EasyMock\EasyMock;
@@ -57,11 +58,11 @@ class InstanceDefinitionResolverTest extends \PHPUnit_Framework_TestCase
 
     private function buildResolver()
     {
-        /** @var \DI\Container $container */
-        $container = EasyMock::mock('DI\Container');
+        /** @var ResolverDispatcher $resolverDispatcher */
+        $resolverDispatcher = EasyMock::mock('DI\Definition\Resolver\ResolverDispatcher');
         /** @var ProxyFactory $factory */
         $factory = EasyMock::mock('DI\Proxy\ProxyFactory');
 
-        return new InstanceDefinitionResolver($container, $factory);
+        return new InstanceDefinitionResolver($resolverDispatcher, $factory);
     }
 }


### PR DESCRIPTION
This PR addresses #208 to add support for nested definitions in:

- [x] object definitions (`DI\object()`)
- [x] environment variables (`DI\env()`)
- [x] arrays (`[]` or `DI\add()`)

It also contains a refactoring to simplify the code: `DI\link()` is now considered like any other nested definition (before there was special support for this everywhere because it was the only definition you could use inside another one).

Example:

```php
return [
    Db::class => DI\object()
        ->constructor(
            \DI\object(DbConfig::class)
                ->constructor(
                    \DI\env('DATABASE_HOST')
                )
        ),
];
```