### PR TITLE
Documentation change: Alter factory() example to use safer type-hinting

### DIFF
--- a/doc/definition.md
+++ b/doc/definition.md
@@ -210,7 +210,7 @@ return [
     'myNamedInstance' => DI\object('My\Class'),
 
     // Using an anonymous function
-    'My\Stuff' => DI\factory(function (Container $c) {
+    'My\Stuff' => DI\factory(function (\Interop\Container\ContainerInterface $c) {
         return new MyClass($c->get('db.host'));
     }),
 


### PR DESCRIPTION
Currently, the example code type-hints with `\DI\Container`, which will break when following the documentation for Symfony-2 integration, since `DI\Bridge\Symfony\SymfonyContainerBridge` is not a subclass.

This problem is avoided by type-hinting with `\Interop\Container\ContainerInterface` instead. (Due to `\DI\ContainerInterface` being deprecated.)