### PR TITLE
Replaced DI\link() with DI\get() and marked DI\link() as deprecated

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -19,6 +19,7 @@ Improvements:
         return new Foo();
     }
     ```
+- [#235](https://github.com/mnapoli/PHP-DI/issues/235) `DI\link()` is now deprecated in favor of `DI\get()`. There is no BC break as `DI\link()` still works.
 
 BC breaks:
 

--- a/doc/best-practices.md
+++ b/doc/best-practices.md
@@ -126,7 +126,7 @@ Example:
 return [
     // ...
     OrderService::class => DI\object()
-        ->constructor(DI\link(SomeOtherService::class), 'a value'),
+        ->constructor(DI\get(SomeOtherService::class), 'a value'),
 ];
 ```
 

--- a/doc/container.md
+++ b/doc/container.md
@@ -122,7 +122,7 @@ Note that you can also define injections on the fly if you don't use type-hints:
 
 ```php
 $parameters = [
-    'logger' => \DI\link('Logger')
+    'logger' => \DI\get('Logger')
 ];
 
 $container->call(function ($logger) {

--- a/doc/definition-overriding.md
+++ b/doc/definition-overriding.md
@@ -49,7 +49,7 @@ You can go even further by overriding this definition using file-based definitio
 
 return [
     'Foo' => DI\object()
-        ->constructor(DI\link('another.specific.service')),
+        ->constructor(DI\get('another.specific.service')),
 
     'another.specific.service' => DI\object('Bar'),
 ];
@@ -59,5 +59,5 @@ Finally, you can also override the file-based definition by directly calling the
 
 ```php
 $container->set('Foo')
-    ->constructor(DI\link('yet.another.specific.service'));
+    ->constructor(DI\get('yet.another.specific.service'));
 ```

--- a/doc/definition.md
+++ b/doc/definition.md
@@ -164,7 +164,7 @@ PHP-DI provides function helpers for this (to define *values*, you don't need a 
 
 - `DI\object($classname = null)`: define an object entry
 - `DI\factory($factory)`: define a factory that returns an entry
-- `DI\link($entryName)`: used to define alias entries, and also to reference other entries in object definitions (see below)
+- `DI\get($entryName)`: used to define alias entries, and also to reference other entries in object definitions (see below) - was previously `DI\link()` in PHP-DI 4, which is kept for backward compatibility
 - `DI\value($value)`: defines a simple value. This helper is not needed as anything is a value by default. The only use case for this helper is to define a container entry that is a closure (as closure are turned into factory definitions automatically)
 
 Example of a `config.php` file (using [PHP 5.4 short arrays](http://php.net/manual/en/migration54.new-features.php)):
@@ -191,18 +191,18 @@ return [
 
     // Defines an instance of My\Class
     'My\Class' => DI\object()
-        ->constructor(DI\link('db.host'), DI\link('My\OtherClass')),
+        ->constructor(DI\get('db.host'), DI\get('My\OtherClass')),
 
     'My\OtherClass' => DI\object()
         ->scope(Scope::PROTOTYPE())
-        ->constructor(DI\link('db.host'), DI\link('db.port'))
-        ->method('setFoo2', DI\link('My\Foo1'), DI\link('My\Foo2'))
+        ->constructor(DI\get('db.host'), DI\get('db.port'))
+        ->method('setFoo2', DI\get('My\Foo1'), DI\get('My\Foo2'))
         ->property('bar', 'My\Bar'),
 
     // Define only specific parameters
     'My\AnotherClass' => DI\object()
         ->constructorParameter('someParam', 'value to inject')
-        ->methodParameter('setFoo2', 'someParam', DI\link('My\Foo')),
+        ->methodParameter('setFoo2', 'someParam', DI\get('My\Foo')),
 
     // Mapping an interface to an implementation
     'My\Interface' => DI\object('My\Implementation'),
@@ -222,19 +222,19 @@ return [
     })->scope(Scope::PROTOTYPE()),
 
     // Defining an alias to another entry
-    'some.entry' => DI\link('some.other.entry'),
+    'some.entry' => DI\get('some.other.entry'),
 
     // Defining a value based on an environment variable
     'db1.url' => DI\env('DATABASE_URL'),
     // With a default value
     'db2.url' => DI\env('DATABASE_URL', 'postgresql://user:pass@localhost/db'),
     // With a default value that is another entry
-    'db2.host' => DI\env('DATABASE_HOST', DI\link('db.host')),
+    'db2.host' => DI\env('DATABASE_HOST', DI\get('db.host')),
 
     // Arrays can contain links to other entries
     'log.handlers' => [
-        DI\link('Monolog\Handler\StreamHandler'),
-        DI\link('Monolog\Handler\EmailHandler'),
+        DI\get('Monolog\Handler\StreamHandler'),
+        DI\get('Monolog\Handler\EmailHandler'),
     ],
 
 ];

--- a/doc/environments.md
+++ b/doc/environments.md
@@ -14,7 +14,7 @@ return [
     'db.port' => 3336,
 
     'DbAdapter' => DI\object()
-        ->constructor(DI\link('db.host'), DI\link('db.port')),
+        ->constructor(DI\get('db.host'), DI\get('db.port')),
 ];
 ```
 
@@ -43,7 +43,7 @@ return [
 // config.php
 return [
     'DbAdapter' => DI\object()
-        ->constructor(DI\link('db.host'), DI\link('db.port')),
+        ->constructor(DI\get('db.host'), DI\get('db.port')),
 ];
 ```
 

--- a/doc/frameworks/symfony2.md
+++ b/doc/frameworks/symfony2.md
@@ -120,7 +120,7 @@ That's because PHP-DI is designed to play nice with others:
 ```php
 return [
     'Acme\MyBundle\Controller\ProductController' => DI\object()
-        ->constructor(DI\link('doctrine.orm.entity_manager')),
+        ->constructor(DI\get('doctrine.orm.entity_manager')),
 ];
 ```
 
@@ -139,9 +139,9 @@ like these:
 
 ```php
 return [
-    'Psr\Log\LoggerInterface' => DI\link('logger'),
+    'Psr\Log\LoggerInterface' => DI\get('logger'),
     // PHP 5.5 notation:
-    ObjectManager::class => DI\link('doctrine.orm.entity_manager'),
+    ObjectManager::class => DI\get('doctrine.orm.entity_manager'),
 ];
 ```
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -112,7 +112,7 @@ return [
 
     // Class
     MyDbAdapter::class => DI\object()
-        ->constructor(DI\link('db.host'), DI\link('db.port')),
+        ->constructor(DI\get('db.host'), DI\get('db.port')),
 
 ];
 ```

--- a/src/DI/Definition/Dumper/AliasDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/AliasDefinitionDumper.php
@@ -34,14 +34,14 @@ class AliasDefinitionDumper implements DefinitionDumper
 
         if ($definition->getName()) {
             return sprintf(
-                "link(%s => %s)",
+                "get(%s => %s)",
                 $definition->getName(),
                 $definition->getTargetEntryName()
             );
         }
 
         return sprintf(
-            "link(%s)",
+            "get(%s)",
             $definition->getTargetEntryName()
         );
     }

--- a/src/DI/Definition/Dumper/ClassDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/ClassDefinitionDumper.php
@@ -90,7 +90,7 @@ class ClassDefinitionDumper implements DefinitionDumper
         foreach ($definition->getPropertyInjections() as $propertyInjection) {
             $value = $propertyInjection->getValue();
             if ($value instanceof EntryReference) {
-                $valueStr = sprintf('link(%s)', $value->getName());
+                $valueStr = sprintf('get(%s)', $value->getName());
             } else {
                 $valueStr = var_export($value, true);
             }
@@ -125,7 +125,7 @@ class ClassDefinitionDumper implements DefinitionDumper
                 $value = $methodInjection->getParameter($index);
 
                 if ($value instanceof EntryReference) {
-                    $args[] = sprintf('$%s = link(%s)', $parameter->getName(), $value->getName());
+                    $args[] = sprintf('$%s = get(%s)', $parameter->getName(), $value->getName());
                 } else {
                     $args[] = sprintf('$%s = %s', $parameter->getName(), var_export($value, true));
                 }

--- a/src/DI/Definition/Dumper/FunctionCallDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/FunctionCallDefinitionDumper.php
@@ -55,7 +55,7 @@ class FunctionCallDefinitionDumper implements DefinitionDumper
                 $value = $definition->getParameter($index);
 
                 if ($value instanceof EntryReference) {
-                    $args[] = sprintf('$%s = link(%s)', $parameter->getName(), $value->getName());
+                    $args[] = sprintf('$%s = get(%s)', $parameter->getName(), $value->getName());
                 } else {
                     $args[] = sprintf('$%s = %s', $parameter->getName(), var_export($value, true));
                 }

--- a/src/DI/functions.php
+++ b/src/DI/functions.php
@@ -61,9 +61,25 @@ if (! function_exists('DI\factory')) {
     }
 }
 
+if (! function_exists('DI\get')) {
+    /**
+     * Helper for referencing another container entry in an object definition.
+     *
+     * @param string $entryName
+     *
+     * @return EntryReference
+     */
+    function get($entryName)
+    {
+        return new EntryReference($entryName);
+    }
+}
+
 if (! function_exists('DI\link')) {
     /**
      * Helper for referencing another container entry in an object definition.
+     *
+     * @deprecated \DI\link() has been replaced by \DI\get()
      *
      * @param string $entryName
      *
@@ -99,12 +115,12 @@ if (! function_exists('DI\add')) {
      *
      * Example:
      *
-     *     'log.backends' => DI\add(DI\link('My\Custom\LogBackend'))
+     *     'log.backends' => DI\add(DI\get('My\Custom\LogBackend'))
      *
      * or:
      *
      *     'log.backends' => DI\add([
-     *         DI\link('My\Custom\LogBackend')
+     *         DI\get('My\Custom\LogBackend')
      *     ])
      *
      * @param mixed|array $values A value or an array of values to add to the array.

--- a/tests/IntegrationTest/CallFunctionTest.php
+++ b/tests/IntegrationTest/CallFunctionTest.php
@@ -46,7 +46,7 @@ class CallFunctionTest extends \PHPUnit_Framework_TestCase
         $result = $container->call(function($foo) {
             return $foo;
         }, array(
-            'foo' => \DI\link('bar'),
+            'foo' => \DI\get('bar'),
         ));
         $this->assertEquals('bam', $result);
     }

--- a/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
@@ -41,8 +41,8 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
         $builder = new ContainerBuilder();
         $builder->addDefinitions(array(
             'links'     => array(
-                \DI\link('singleton'),
-                \DI\link('prototype'),
+                \DI\get('singleton'),
+                \DI\get('prototype'),
             ),
             'singleton' => \DI\object('stdClass'),
             'prototype' => \DI\object('stdClass')
@@ -87,7 +87,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
         $builder = new ContainerBuilder();
         $builder->addDefinitions(array(
             'array'     => array(
-                \DI\link('prototype'),
+                \DI\get('prototype'),
             ),
             'prototype' => \DI\object('stdClass')
                 ->scope(Scope::PROTOTYPE()),
@@ -112,7 +112,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
         $builder->addDefinitions(array(
             'values' => \DI\add(array(
                 'another value',
-                \DI\link('foo'),
+                \DI\get('foo'),
             )),
             'foo'    => \DI\object('stdClass'),
         ));

--- a/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/EnvironmentVariableDefinitionTest.php
@@ -77,7 +77,7 @@ class EnvironmentVariableDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $builder->addDefinitions(array(
-            'var' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\link('foo')),
+            'var' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\get('foo')),
             'foo' => 'bar',
         ));
         $container = $builder->build();

--- a/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
+++ b/tests/IntegrationTest/Definitions/NestedDefinitionsTest.php
@@ -28,7 +28,7 @@ class NestedDefinitionsTest extends \PHPUnit_Framework_TestCase
 
         $builder->addDefinitions(array(
             'foo'    => 'bar',
-            'link'   => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\link('foo')),
+            'link'   => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\get('foo')),
             'object' => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\object('stdClass')),
         ));
 
@@ -59,7 +59,7 @@ class NestedDefinitionsTest extends \PHPUnit_Framework_TestCase
                         return $impl;
                     })
                 )
-                ->property('property1', \DI\link('foo'))
+                ->property('property1', \DI\get('foo'))
                 ->property('property2', \DI\factory(function () use ($impl) {
                     return $impl;
                 })),
@@ -89,8 +89,8 @@ class NestedDefinitionsTest extends \PHPUnit_Framework_TestCase
         $builder->addDefinitions(array(
             'foo'   => 'bar',
             'array' => array(
-                'env'    => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\link('foo')),
-                'link'   => \DI\link('foo'),
+                'env'    => \DI\env('PHP_DI_DO_NOT_DEFINE_THIS', \DI\get('foo')),
+                'link'   => \DI\get('foo'),
                 'object' => \DI\object('stdClass'),
             ),
         ));

--- a/tests/IntegrationTest/Fixtures/definitions.php
+++ b/tests/IntegrationTest/Fixtures/definitions.php
@@ -7,22 +7,22 @@ return array(
 
     'DI\Test\IntegrationTest\Fixtures\Class1' => DI\object()
             ->scope(Scope::PROTOTYPE())
-            ->property('property1', DI\link('DI\Test\IntegrationTest\Fixtures\Class2'))
-            ->property('property2', DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'))
-            ->property('property3', DI\link('namedDependency'))
-            ->property('property4', DI\link('foo'))
-            ->property('property5', DI\link('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
+            ->property('property1', DI\get('DI\Test\IntegrationTest\Fixtures\Class2'))
+            ->property('property2', DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
+            ->property('property3', DI\get('namedDependency'))
+            ->property('property4', DI\get('foo'))
+            ->property('property5', DI\get('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
             ->constructor(
-                DI\link('DI\Test\IntegrationTest\Fixtures\Class2'),
-                DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'),
-                DI\link('DI\Test\IntegrationTest\Fixtures\LazyDependency')
+                DI\get('DI\Test\IntegrationTest\Fixtures\Class2'),
+                DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'),
+                DI\get('DI\Test\IntegrationTest\Fixtures\LazyDependency')
             )
-            ->method('method1', DI\link('DI\Test\IntegrationTest\Fixtures\Class2'))
-            ->method('method2', DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'))
-            ->method('method3', DI\link('namedDependency'), DI\link('foo'))
-            ->method('method4', DI\link('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
-            ->methodParameter('method5', 'param1', \DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'))
-            ->methodParameter('method5', 'param2', \DI\link('foo')),
+            ->method('method1', DI\get('DI\Test\IntegrationTest\Fixtures\Class2'))
+            ->method('method2', DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
+            ->method('method3', DI\get('namedDependency'), DI\get('foo'))
+            ->method('method4', DI\get('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
+            ->methodParameter('method5', 'param1', \DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
+            ->methodParameter('method5', 'param2', \DI\get('foo')),
 
     'DI\Test\IntegrationTest\Fixtures\Class2' => DI\object(),
 
@@ -37,5 +37,5 @@ return array(
     'DI\Test\IntegrationTest\Fixtures\LazyDependency' => DI\object()
             ->lazy(),
 
-    'alias' => DI\link('namedDependency'),
+    'alias' => DI\get('namedDependency'),
 );

--- a/tests/IntegrationTest/InheritanceTest.php
+++ b/tests/IntegrationTest/InheritanceTest.php
@@ -80,18 +80,18 @@ class InheritanceTest extends \PHPUnit_Framework_TestCase
         $containerPHPDefinitions->set(
             'DI\Test\IntegrationTest\Fixtures\InheritanceTest\BaseClass',
             \DI\object('DI\Test\IntegrationTest\Fixtures\InheritanceTest\SubClass')
-                ->property('property1', \DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
-                ->property('property4', \DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
-                ->constructor(\DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
-                ->method('setProperty2', \DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->property('property1', \DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->property('property4', \DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->constructor(\DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->method('setProperty2', \DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
         );
         $containerPHPDefinitions->set(
             'DI\Test\IntegrationTest\Fixtures\InheritanceTest\SubClass',
             \DI\object()
-                ->property('property1', \DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
-                ->property('property4', \DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
-                ->constructor(\DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
-                ->method('setProperty2', \DI\link('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->property('property1', \DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->property('property4', \DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->constructor(\DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
+                ->method('setProperty2', \DI\get('DI\Test\IntegrationTest\Fixtures\InheritanceTest\Dependency'))
         );
 
         return array(

--- a/tests/IntegrationTest/InjectionTest.php
+++ b/tests/IntegrationTest/InjectionTest.php
@@ -49,7 +49,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
         );
         $containerReflection->set('namedDependency', \DI\object('DI\Test\IntegrationTest\Fixtures\Class2'));
         $containerReflection->set('DI\Test\IntegrationTest\Fixtures\LazyDependency', \DI\object()->lazy());
-        $containerReflection->set('alias', \DI\link('namedDependency'));
+        $containerReflection->set('alias', \DI\get('namedDependency'));
 
         // Test with a container using annotations and reflection
         $builder = new ContainerBuilder();
@@ -63,7 +63,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
             \DI\object('DI\Test\IntegrationTest\Fixtures\Implementation1')
         );
         $containerAnnotations->set('namedDependency', \DI\object('DI\Test\IntegrationTest\Fixtures\Class2'));
-        $containerAnnotations->set('alias', \DI\link('namedDependency'));
+        $containerAnnotations->set('alias', \DI\get('namedDependency'));
 
         // Test with a container using array configuration
         $builder = new ContainerBuilder();
@@ -82,22 +82,22 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
             'DI\Test\IntegrationTest\Fixtures\Class1',
             \DI\object()
                 ->scope(Scope::PROTOTYPE())
-                ->property('property1', \DI\link('DI\Test\IntegrationTest\Fixtures\Class2'))
-                ->property('property2', \DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'))
-                ->property('property3', \DI\link('namedDependency'))
-                ->property('property4', \DI\link('foo'))
-                ->property('property5', \DI\link('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
+                ->property('property1', \DI\get('DI\Test\IntegrationTest\Fixtures\Class2'))
+                ->property('property2', \DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
+                ->property('property3', \DI\get('namedDependency'))
+                ->property('property4', \DI\get('foo'))
+                ->property('property5', \DI\get('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
                 ->constructor(
-                    \DI\link('DI\Test\IntegrationTest\Fixtures\Class2'),
-                    \DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'),
-                    \DI\link('DI\Test\IntegrationTest\Fixtures\LazyDependency')
+                    \DI\get('DI\Test\IntegrationTest\Fixtures\Class2'),
+                    \DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'),
+                    \DI\get('DI\Test\IntegrationTest\Fixtures\LazyDependency')
                 )
-                ->method('method1', \DI\link('DI\Test\IntegrationTest\Fixtures\Class2'))
-                ->method('method2', \DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'))
-                ->method('method3', \DI\link('namedDependency'), \DI\link('foo'))
-                ->method('method4', \DI\link('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
-                ->methodParameter('method5', 'param1', \DI\link('DI\Test\IntegrationTest\Fixtures\Interface1'))
-                ->methodParameter('method5', 'param2', \DI\link('foo'))
+                ->method('method1', \DI\get('DI\Test\IntegrationTest\Fixtures\Class2'))
+                ->method('method2', \DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
+                ->method('method3', \DI\get('namedDependency'), \DI\get('foo'))
+                ->method('method4', \DI\get('DI\Test\IntegrationTest\Fixtures\LazyDependency'))
+                ->methodParameter('method5', 'param1', \DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
+                ->methodParameter('method5', 'param2', \DI\get('foo'))
         );
         $containerPHP->set('DI\Test\IntegrationTest\Fixtures\Class2', \DI\object());
         $containerPHP->set('DI\Test\IntegrationTest\Fixtures\Implementation1', \DI\object());
@@ -108,7 +108,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
         );
         $containerPHP->set('namedDependency', \DI\object('DI\Test\IntegrationTest\Fixtures\Class2'));
         $containerPHP->set('DI\Test\IntegrationTest\Fixtures\LazyDependency', \DI\object()->lazy());
-        $containerPHP->set('alias', \DI\link('namedDependency'));
+        $containerPHP->set('alias', \DI\get('namedDependency'));
 
         return array(
             'autowiring' => array(self::DEFINITION_REFLECTION, $containerReflection),

--- a/tests/IntegrationTest/Issues/Issue72/definitions.php
+++ b/tests/IntegrationTest/Issues/Issue72/definitions.php
@@ -7,5 +7,5 @@ return array(
         return $value;
     }),
     'DI\Test\IntegrationTest\Issues\Issue72\Class1' => \DI\object()
-            ->constructor(\DI\link('service2')),
+            ->constructor(\DI\get('service2')),
 );

--- a/tests/IntegrationTest/Issues/Issue72/definitions2.php
+++ b/tests/IntegrationTest/Issues/Issue72/definitions2.php
@@ -7,5 +7,5 @@ return array(
         return $value;
     }),
     'DI\Test\IntegrationTest\Issues\Issue72\Class1' => \DI\object()
-            ->constructor(\DI\link('service3')),
+            ->constructor(\DI\get('service3')),
 );

--- a/tests/IntegrationTest/Issues/Issue72Test.php
+++ b/tests/IntegrationTest/Issues/Issue72Test.php
@@ -118,7 +118,7 @@ class Issue72Test extends \PHPUnit_Framework_TestCase
         $container->set(
             'DI\Test\IntegrationTest\Issues\Issue72\Class1',
             \DI\object()
-                ->constructor(\DI\link('service2'))
+                ->constructor(\DI\get('service2'))
         );
 
         /** @var Class1 $class1 */

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -116,7 +116,7 @@ class ContainerGetTest extends \PHPUnit_Framework_TestCase
     {
         $container = ContainerBuilder::buildDevContainer();
         // Alias to itself -> infinite recursive loop
-        $container->set('foo', \DI\link('foo'));
+        $container->set('foo', \DI\get('foo'));
         $container->get('foo');
     }
 

--- a/tests/UnitTest/ContainerMakeTest.php
+++ b/tests/UnitTest/ContainerMakeTest.php
@@ -119,7 +119,7 @@ class ContainerMakeTest extends \PHPUnit_Framework_TestCase
     {
         $container = ContainerBuilder::buildDevContainer();
         // Alias to itself -> infinite recursive loop
-        $container->set('foo', \DI\link('foo'));
+        $container->set('foo', \DI\get('foo'));
         $container->make('foo');
     }
 

--- a/tests/UnitTest/Definition/Dumper/AliasDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/AliasDefinitionDumperTest.php
@@ -26,7 +26,7 @@ class AliasDefinitionDumperTest extends \PHPUnit_Framework_TestCase
         $definition = new AliasDefinition('foo', 'bar');
         $dumper = new AliasDefinitionDumper();
 
-        $str = 'link(foo => bar)';
+        $str = 'get(foo => bar)';
 
         $this->assertEquals($str, $dumper->dump($definition));
     }

--- a/tests/UnitTest/Definition/Dumper/ArrayDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ArrayDefinitionDumperTest.php
@@ -60,13 +60,13 @@ class ArrayDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     public function should_dump_array_containing_nested_definitions()
     {
         $definition = new ArrayDefinition('foo', array(
-            \DI\link('foo'),
+            \DI\get('foo'),
             \DI\env('foo'),
         ));
         $dumper = new ArrayDefinitionDumper();
 
         $str = '[
-    0 => link(foo),
+    0 => get(foo),
     1 => Environment variable (
         variable = foo
         optional = no

--- a/tests/UnitTest/Definition/Dumper/ClassDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ClassDefinitionDumperTest.php
@@ -23,8 +23,8 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     {
         $definition = \DI\object('DI\Test\UnitTest\Definition\Dumper\FixtureClass')
             ->lazy()
-            ->constructor(\DI\link('Mailer'), 'email@example.com')
-            ->method('setFoo', \DI\link('SomeDependency'))
+            ->constructor(\DI\get('Mailer'), 'email@example.com')
+            ->method('setFoo', \DI\get('SomeDependency'))
             ->property('prop', 'Some value')
             ->getDefinition('foo');
         $dumper = new ClassDefinitionDumper();
@@ -34,12 +34,12 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     scope = singleton
     lazy = true
     __construct(
-        $mailer = link(Mailer)
+        $mailer = get(Mailer)
         $contactEmail = \'email@example.com\'
     )
     $prop = \'Some value\'
     setFoo(
-        $foo = link(SomeDependency)
+        $foo = get(SomeDependency)
     )
 )';
 
@@ -127,7 +127,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     public function testConstructorParameters()
     {
         $definition = \DI\object('DI\Test\UnitTest\Definition\Dumper\FixtureClass')
-            ->constructor(\DI\link('Mailer'), 'email@example.com')
+            ->constructor(\DI\get('Mailer'), 'email@example.com')
             ->getDefinition('foo');
         $resolver = new ClassDefinitionDumper();
 
@@ -136,7 +136,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     scope = singleton
     lazy = false
     __construct(
-        $mailer = link(Mailer)
+        $mailer = get(Mailer)
         $contactEmail = \'email@example.com\'
     )
 )';
@@ -147,7 +147,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     public function testUndefinedConstructorParameter()
     {
         $definition = \DI\object('DI\Test\UnitTest\Definition\Dumper\FixtureClass')
-            ->constructor(\DI\link('Mailer'))
+            ->constructor(\DI\get('Mailer'))
             ->getDefinition('foo');
         $resolver = new ClassDefinitionDumper();
 
@@ -156,7 +156,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     scope = singleton
     lazy = false
     __construct(
-        $mailer = link(Mailer)
+        $mailer = get(Mailer)
         $contactEmail = #UNDEFINED#
     )
 )';
@@ -181,10 +181,10 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($str, $resolver->dump($definition));
     }
 
-    public function testPropertyLink()
+    public function testPropertyget()
     {
         $definition = \DI\object('DI\Test\UnitTest\Definition\Dumper\FixtureClass')
-            ->property('prop', \DI\link('foo'))
+            ->property('prop', \DI\get('foo'))
             ->getDefinition('foo');
         $resolver = new ClassDefinitionDumper();
 
@@ -192,7 +192,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     class = DI\Test\UnitTest\Definition\Dumper\FixtureClass
     scope = singleton
     lazy = false
-    $prop = link(foo)
+    $prop = get(foo)
 )';
 
         $this->assertEquals($str, $resolver->dump($definition));
@@ -201,7 +201,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     public function testMethodLinkParameter()
     {
         $definition = \DI\object('DI\Test\UnitTest\Definition\Dumper\FixtureClass')
-            ->method('setFoo', \DI\link('Mailer'))
+            ->method('setFoo', \DI\get('Mailer'))
             ->getDefinition('foo');
         $resolver = new ClassDefinitionDumper();
 
@@ -210,7 +210,7 @@ class ClassDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     scope = singleton
     lazy = false
     setFoo(
-        $foo = link(Mailer)
+        $foo = get(Mailer)
     )
 )';
 

--- a/tests/UnitTest/Definition/Dumper/EnvironmentVariableDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/EnvironmentVariableDefinitionDumperTest.php
@@ -73,13 +73,13 @@ class EnvironmentVariableDefinitionDumperTest extends \PHPUnit_Framework_TestCas
         $str = 'Environment variable (
     variable = bar
     optional = yes
-    default = link(foo)
+    default = get(foo)
 )';
 
         $this->assertEquals(
             $str,
             $this->dumper->dump(
-                new EnvironmentVariableDefinition('foo', 'bar', true, \DI\link('foo'))
+                new EnvironmentVariableDefinition('foo', 'bar', true, \DI\get('foo'))
             )
         );
     }

--- a/tests/UnitTest/Definition/Dumper/FunctionCallDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/FunctionCallDefinitionDumperTest.php
@@ -26,14 +26,14 @@ class FunctionCallDefinitionDumperTest extends \PHPUnit_Framework_TestCase
         });
         $definition->replaceParameters(array(
             1  => 'bar',
-            2 => \DI\link('foo'),
+            2 => \DI\get('foo'),
         ));
         $dumper = new FunctionCallDefinitionDumper();
 
         $str = 'closure defined in ' . __FILE__ . ' at line 25(
     $undefined = #UNDEFINED#
     $foo = \'bar\'
-    $link = link(foo)
+    $link = get(foo)
     $default = (default value) \'foo\'
 )';
 

--- a/tests/UnitTest/Definition/Resolver/ArrayDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/ArrayDefinitionResolverTest.php
@@ -67,7 +67,7 @@ class ArrayDefinitionResolverTest extends \PHPUnit_Framework_TestCase
 
         $definition = new ArrayDefinition('foo', array(
             'bar',
-            \DI\link('bar'),
+            \DI\get('bar'),
             \DI\object('bar'),
         ));
 
@@ -111,7 +111,7 @@ class ArrayDefinitionResolverTest extends \PHPUnit_Framework_TestCase
             ->willThrowException(new \Exception('This is a message'));
 
         $this->resolver->resolve(new ArrayDefinition('foo', array(
-            \DI\link('bar'),
+            \DI\get('bar'),
         )));
     }
 }

--- a/tests/UnitTest/Definition/Resolver/EnvironmentVariableDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/EnvironmentVariableDefinitionResolverTest.php
@@ -53,7 +53,7 @@ class EnvironmentVariableDefinitionResolverTest extends \PHPUnit_Framework_TestC
         $this->definedDefinition = new EnvironmentVariableDefinition('foo', 'DEFINED');
         $this->undefinedDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED');
         $this->optionalDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED', true, '<default>');
-        $this->nestedDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED', true, \DI\link('foo'));
+        $this->nestedDefinition = new EnvironmentVariableDefinition('foo', 'UNDEFINED', true, \DI\get('foo'));
         $this->invalidDefinition = new FactoryDefinition('foo', function () {});
     }
 

--- a/tests/UnitTest/Definition/Resolver/FunctionCallDefinitionResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/FunctionCallDefinitionResolverTest.php
@@ -61,7 +61,7 @@ class FunctionCallDefinitionResolverTest extends \PHPUnit_Framework_TestCase
 
         $definition = $this->definition(function ($foo, $bar) {
             return array($foo, $bar);
-        }, array('foo', \DI\link('bar')));
+        }, array('foo', \DI\get('bar')));
 
         $this->assertEquals(array('foo', 42), $this->resolver->resolve($definition));
     }

--- a/tests/UnitTest/Definition/Source/ArrayDefinitionSourceTest.php
+++ b/tests/UnitTest/Definition/Source/ArrayDefinitionSourceTest.php
@@ -72,7 +72,7 @@ class ArrayDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $definitions = array(
             'array'   => array('a', 'b', 'c'),
             'assoc'   => array('a' => 'b'),
-            'links'   => array('a' => \DI\link('b')),
+            'links'   => array('a' => \DI\get('b')),
         );
         $source->addDefinitions($definitions);
 
@@ -89,7 +89,7 @@ class ArrayDefinitionSourceTest extends \PHPUnit_Framework_TestCase
 
         $definition = $source->getDefinition('links');
         $this->assertTrue($definition instanceof ArrayDefinition);
-        $this->assertEquals(array('a' => \DI\link('b')), $definition->getValues());
+        $this->assertEquals(array('a' => \DI\get('b')), $definition->getValues());
         $this->assertInternalType('array', $definition->getValues());
     }
 

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -56,6 +56,17 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::\DI\get
+     */
+    public function test_get()
+    {
+        $reference = \DI\get('foo');
+
+        $this->assertInstanceOf('DI\Definition\EntryReference', $reference);
+        $this->assertEquals('foo', $reference->getName());
+    }
+
+    /**
      * @covers ::\DI\link
      */
     public function test_link()

--- a/website/home.twig
+++ b/website/home.twig
@@ -137,7 +137,7 @@ return [
     }),
 
     Foo::class => object()
-      ->constructor(link(Bar::class)),
+      ->constructor(get(Bar::class)),
 ];
 </code></pre>
                     </div>
@@ -269,7 +269,7 @@ return [
                     <div class="img-w hover-fader">
 <pre><code class="php small">return [
     Foo::class => object()
-      ->constructor(link(Bar::class))
+      ->constructor(get(Bar::class))
 ];
 </code></pre>
                     </div>


### PR DESCRIPTION
This is the pull request for #235

Short summary: `DI\link()` cannot be imported to `link()` as there is a PHP function named `link()` already.

To solve that, `DI\get()` (new function) should be used instead from 5.0 and on, and `DI\link()` is deprecated. **`DI\link()` will not be removed in 5.* so this is not a BC break.**