### PR TITLE
DI\object()->method() now allows to call the same method twice

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -20,6 +20,7 @@ Improvements:
     }
     ```
 - [#235](https://github.com/mnapoli/PHP-DI/issues/235) `DI\link()` is now deprecated in favor of `DI\get()`. There is no BC break as `DI\link()` still works.
+- [#193](https://github.com/mnapoli/PHP-DI/issues/193) `DI\object()->method()` now supports calling the same method twice (or more).
 
 BC breaks:
 

--- a/doc/definition.md
+++ b/doc/definition.md
@@ -199,6 +199,11 @@ return [
         ->method('setFoo2', DI\get('My\Foo1'), DI\get('My\Foo2'))
         ->property('bar', 'My\Bar'),
 
+    // Call a method twice
+    'My\Logger' => DI\object()
+        ->method('addBackend', 'file')
+        ->method('addBackend', 'syslog'),
+
     // Define only specific parameters
     'My\AnotherClass' => DI\object()
         ->constructorParameter('someParam', 'value to inject')

--- a/src/DI/Definition/ClassDefinition/MethodInjection.php
+++ b/src/DI/Definition/ClassDefinition/MethodInjection.php
@@ -46,7 +46,7 @@ class MethodInjection extends AbstractFunctionCallDefinition
         return $this->methodName;
     }
 
-    public function merge(self $definition)
+    public function merge(MethodInjection $definition)
     {
         // In case of conflicts, the current definition prevails.
         $this->parameters = $this->parameters + $definition->parameters;

--- a/tests/IntegrationTest/DefinitionsTest.php
+++ b/tests/IntegrationTest/DefinitionsTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\IntegrationTest;
+
+use DI\ContainerBuilder;
+
+/**
+ * Test the definition syntax.
+ *
+ * @coversNothing
+ */
+class DefinitionsTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_multiple_method_call()
+    {
+        $container = $this->createContainer(array(
+            'DI\Test\IntegrationTest\Fixtures\DefinitionTest\Class1' => \DI\object()
+                ->method('increment')
+                ->method('increment'),
+        ));
+
+        $class = $container->get('DI\Test\IntegrationTest\Fixtures\DefinitionTest\Class1');
+        $this->assertEquals(2, $class->count);
+    }
+
+    public function test_override_parameter_with_multiple_method_call()
+    {
+        $container = $this->createContainer(
+            array(
+                'DI\Test\IntegrationTest\Fixtures\DefinitionTest\Class1' => \DI\object()
+                    ->method('add', 'foo')
+                    ->method('add', 'foo'),
+            ),
+            array(
+                // Override a method parameter
+                'DI\Test\IntegrationTest\Fixtures\DefinitionTest\Class1' => \DI\object()
+                    ->methodParameter('add', 0, 'bar'),
+            )
+        );
+
+        // Should override only the first method call
+        $class = $container->get('DI\Test\IntegrationTest\Fixtures\DefinitionTest\Class1');
+        $this->assertEquals(array('bar', 'foo'), $class->items);
+    }
+
+    private function createContainer(array $definitions, array $definitions2 = array())
+    {
+        $builder = new ContainerBuilder();
+        $builder->useAutowiring(false);
+        $builder->useAnnotations(false);
+        $builder->addDefinitions($definitions);
+        if (! empty($definitions2)) {
+            $builder->addDefinitions($definitions2);
+        }
+        return $builder->build();
+    }
+}

--- a/tests/IntegrationTest/Fixtures/DefinitionTest/Class1.php
+++ b/tests/IntegrationTest/Fixtures/DefinitionTest/Class1.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DI\Test\IntegrationTest\Fixtures\DefinitionTest;
+
+class Class1
+{
+    public $count = 0;
+    public $items = array();
+
+    public function increment()
+    {
+        $this->count++;
+    }
+
+    public function add($item)
+    {
+        $this->items[] = $item;
+    }
+}

--- a/tests/UnitTest/Definition/ClassDefinitionTest.php
+++ b/tests/UnitTest/Definition/ClassDefinitionTest.php
@@ -72,7 +72,7 @@ class ClassDefinitionTest extends \PHPUnit_Framework_TestCase
         $definition = new ClassDefinition('foo', 'bar');
         $definition->addPropertyInjection(new PropertyInjection('property1', 'Property1'));
         $definition->addPropertyInjection(new PropertyInjection('property2', 'Property2'));
-        $definition->addMethodInjection(new MethodInjection('method1'));
+        $definition->addMethodInjection(new MethodInjection('method1', array('foo')));
         $definition->addMethodInjection(new MethodInjection('method2'));
 
         $subDefinition = new ClassDefinition('bar');
@@ -81,7 +81,7 @@ class ClassDefinitionTest extends \PHPUnit_Framework_TestCase
         $subDefinition->setConstructorInjection(MethodInjection::constructor());
         $subDefinition->addPropertyInjection(new PropertyInjection('property1', 'Property1'));
         $subDefinition->addPropertyInjection(new PropertyInjection('property3', 'Property3'));
-        $subDefinition->addMethodInjection(new MethodInjection('method1'));
+        $subDefinition->addMethodInjection(new MethodInjection('method1', array('bar')));
         $subDefinition->addMethodInjection(new MethodInjection('method3'));
 
         $definition->setSubDefinition($subDefinition);
@@ -93,5 +93,37 @@ class ClassDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($definition->getConstructorInjection());
         $this->assertCount(3, $definition->getPropertyInjections());
         $this->assertCount(3, $definition->getMethodInjections());
+        $this->assertEquals(array(
+            new MethodInjection('method1', array('foo')),
+            new MethodInjection('method2'),
+            new MethodInjection('method3'),
+        ), $definition->getMethodInjections());
+    }
+
+    /**
+     * @test
+     */
+    public function should_merge_multiple_method_calls()
+    {
+        $definition = new ClassDefinition('foo');
+        $definition->addMethodInjection(new MethodInjection('method1'));
+        $definition->addMethodInjection(new MethodInjection('method2', array('bam')));
+        $definition->addMethodInjection(new MethodInjection('method2', array('baz')));
+
+        $subDefinition = new ClassDefinition('bar');
+        $subDefinition->addMethodInjection(new MethodInjection('method1', array('bar')));
+        $subDefinition->addMethodInjection(new MethodInjection('method2', array('foo', 'bar')));
+        $subDefinition->addMethodInjection(new MethodInjection('method3'));
+        $subDefinition->addMethodInjection(new MethodInjection('method3'));
+
+        $definition->setSubDefinition($subDefinition);
+
+        $this->assertEquals(array(
+            new MethodInjection('method1', array('bar')),
+            new MethodInjection('method2', array('bam', 'bar')),
+            new MethodInjection('method2', array('baz')),
+            new MethodInjection('method3'),
+            new MethodInjection('method3'),
+        ), $definition->getMethodInjections());
     }
 }

--- a/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ClassDefinitionHelperTest.php
@@ -18,7 +18,10 @@ use DI\Scope;
  */
 class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
 {
-    public function testDefaultValues()
+    /**
+     * @test
+     */
+    public function test_default_config()
     {
         $helper = new ClassDefinitionHelper();
         $definition = $helper->getDefinition('foo');
@@ -31,7 +34,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($definition->getMethodInjections());
     }
 
-    public function testClassName()
+    /**
+     * @test
+     */
+    public function allows_to_define_the_class_name()
     {
         $helper = new ClassDefinitionHelper('bar');
         $definition = $helper->getDefinition('foo');
@@ -40,7 +46,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $definition->getClassName());
     }
 
-    public function testScope()
+    /**
+     * @test
+     */
+    public function allows_to_define_the_scope()
     {
         $helper = new ClassDefinitionHelper();
         $helper->scope(Scope::PROTOTYPE());
@@ -49,7 +58,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
     }
 
-    public function testLazy()
+    /**
+     * @test
+     */
+    public function allows_to_declare_the_service_as_lazy()
     {
         $helper = new ClassDefinitionHelper();
         $helper->lazy();
@@ -58,7 +70,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($definition->isLazy());
     }
 
-    public function testConstructor()
+    /**
+     * @test
+     */
+    public function allows_to_define_constructor_parameters()
     {
         $helper = new ClassDefinitionHelper();
         $helper->constructor(1, 2, 3);
@@ -67,7 +82,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(1, 2, 3), $definition->getConstructorInjection()->getParameters());
     }
 
-    public function testConstructorParameter()
+    /**
+     * @test
+     */
+    public function allows_to_override_a_parameter_injection()
     {
         $helper = new ClassDefinitionHelper();
         $helper->constructorParameter(0, 42);
@@ -78,7 +96,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(42, $constructorInjection->getParameter(0));
     }
 
-    public function testPropertyInjections()
+    /**
+     * @test
+     */
+    public function allows_to_define_a_property_injection()
     {
         $helper = new ClassDefinitionHelper();
         $helper->property('prop', 1);
@@ -89,7 +110,10 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $propertyInjection->getValue());
     }
 
-    public function testMethodInjections()
+    /**
+     * @test
+     */
+    public function allows_to_define_a_method_call()
     {
         $helper = new ClassDefinitionHelper();
         $helper->method('method', 1, 2, 3);
@@ -100,7 +124,28 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(1, 2, 3), $methodInjection->getParameters());
     }
 
-    public function testMethodParameter()
+    /**
+     * @test
+     */
+    public function allows_to_define_multiple_method_calls()
+    {
+        $helper = new ClassDefinitionHelper();
+        $helper->method('method', 1, 2);
+        $helper->method('method', 3, 4);
+        $definition = $helper->getDefinition('foo');
+
+        $methodCalls = $definition->getMethodInjections();
+        $this->assertCount(2, $methodCalls);
+        $methodInjection = array_shift($methodCalls);
+        $this->assertEquals(array(1, 2), $methodInjection->getParameters());
+        $methodInjection = array_shift($methodCalls);
+        $this->assertEquals(array(3, 4), $methodInjection->getParameters());
+    }
+
+    /**
+     * @test
+     */
+    public function allows_to_override_a_parameter_injection_by_index()
     {
         $helper = new ClassDefinitionHelper();
         $helper->methodParameter('method', 0, 42);
@@ -115,24 +160,9 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * If using methodParameter() for "__construct", then the constructor definition should be updated
-     */
-    public function testMethodParameterOnConstructor()
-    {
-        $helper = new ClassDefinitionHelper();
-        $helper->methodParameter('__construct', 0, 42);
-        $definition = $helper->getDefinition('foo');
-
-        $this->assertCount(0, $definition->getMethodInjections());
-        $this->assertNotNull($definition->getConstructorInjection());
-
-        $this->assertEquals(42, $definition->getConstructorInjection()->getParameter(0));
-    }
-
-    /**
      * Check using the parameter name, not its index
      */
-    public function testMethodParameterByParameterName()
+    public function allows_to_override_a_parameter_injection_by_name()
     {
         $helper = new ClassDefinitionHelper();
         $helper->methodParameter('method', 'param2', 'val2');
@@ -144,5 +174,20 @@ class ClassDefinitionHelperTest extends \PHPUnit_Framework_TestCase
 
         // Check that injections are in the good order (matching the real parameters order)
         $this->assertEquals(array('val1', 'val2'), $methodInjection->getParameters());
+    }
+
+    /**
+     * If using methodParameter() for "__construct", then the constructor definition should be updated
+     */
+    public function should_update_constructor_definition_if_overriding_parameter_for_constructor()
+    {
+        $helper = new ClassDefinitionHelper();
+        $helper->methodParameter('__construct', 0, 42);
+        $definition = $helper->getDefinition('foo');
+
+        $this->assertCount(0, $definition->getMethodInjections());
+        $this->assertNotNull($definition->getConstructorInjection());
+
+        $this->assertEquals(42, $definition->getConstructorInjection()->getParameter(0));
     }
 }

--- a/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
@@ -9,6 +9,7 @@
 
 namespace DI\Test\UnitTest\Definition\Source;
 
+use DI\Definition\ClassDefinition;
 use DI\Definition\EntryReference;
 use DI\Definition\Source\AnnotationReader;
 use DI\Scope;
@@ -85,8 +86,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $methodInjections = $definition->getMethodInjections();
-        $methodInjection = $methodInjections['method1'];
+        $methodInjection = $this->getMethodInjection($definition, 'method1');
         $this->assertInstanceOf('DI\Definition\ClassDefinition\MethodInjection', $methodInjection);
 
         $this->assertEmpty($methodInjection->getParameters());
@@ -98,8 +98,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $methodInjections = $definition->getMethodInjections();
-        $methodInjection = $methodInjections['method2'];
+        $methodInjection = $this->getMethodInjection($definition, 'method2');
         $this->assertInstanceOf('DI\Definition\ClassDefinition\MethodInjection', $methodInjection);
 
         $parameters = $methodInjection->getParameters();
@@ -114,8 +113,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $methodInjections = $definition->getMethodInjections();
-        $methodInjection = $methodInjections['method3'];
+        $methodInjection = $this->getMethodInjection($definition, 'method3');
         $this->assertInstanceOf('DI\Definition\ClassDefinition\MethodInjection', $methodInjection);
 
         $parameters = $methodInjection->getParameters();
@@ -132,8 +130,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $methodInjections = $definition->getMethodInjections();
-        $methodInjection = $methodInjections['method4'];
+        $methodInjection = $this->getMethodInjection($definition, 'method4');
         $this->assertInstanceOf('DI\Definition\ClassDefinition\MethodInjection', $methodInjection);
 
         $parameters = $methodInjection->getParameters();
@@ -148,8 +145,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $methodInjections = $definition->getMethodInjections();
-        $methodInjection = $methodInjections['method5'];
+        $methodInjection = $this->getMethodInjection($definition, 'method5');
         $this->assertInstanceOf('DI\Definition\ClassDefinition\MethodInjection', $methodInjection);
 
         $parameters = $methodInjection->getParameters();
@@ -164,7 +160,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
 
-        $this->assertNull($definition->getMethodInjection('unannotatedMethod'));
+        $this->assertNull($this->getMethodInjection($definition, 'unannotatedMethod'));
     }
 
     /**
@@ -175,7 +171,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
 
-        $methodInjection = $definition->getMethodInjection('optionalParameter');
+        $methodInjection = $this->getMethodInjection($definition, 'optionalParameter');
 
         $parameters = $methodInjection->getParameters();
         $this->assertCount(1, $parameters);
@@ -189,7 +185,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $source = new AnnotationReader();
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture');
 
-        $this->assertNull($definition->getMethodInjection('staticMethod'));
+        $this->assertNull($this->getMethodInjection($definition, 'staticMethod'));
     }
 
     public function testInjectable()
@@ -211,8 +207,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixture3');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $methodInjections = $definition->getMethodInjections();
-        $methodInjection = $methodInjections['method1'];
+        $methodInjection = $this->getMethodInjection($definition, 'method1');
         $this->assertInstanceOf('DI\Definition\ClassDefinition\MethodInjection', $methodInjection);
 
         $parameters = $methodInjection->getParameters();
@@ -258,8 +253,19 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationFixtureChild');
 
         $this->assertNotNull($definition->getPropertyInjection('propertyChild'));
-        $this->assertNotNull($definition->getMethodInjection('methodChild'));
+        $this->assertNotNull($this->getMethodInjection($definition, 'methodChild'));
         $this->assertNotNull($definition->getPropertyInjection('propertyParent'));
-        $this->assertNotNull($definition->getMethodInjection('methodParent'));
+        $this->assertNotNull($this->getMethodInjection($definition, 'methodParent'));
+    }
+
+    private function getMethodInjection(ClassDefinition $definition, $name)
+    {
+        $methodInjections = $definition->getMethodInjections();
+        foreach ($methodInjections as $methodInjection) {
+            if ($methodInjection->getMethodName() === $name) {
+                return $methodInjection;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
See #193

`DI\object()->method()` now allows to call the same method twice (or more):

```php
    'My\Logger' => DI\object()
        ->method('addBackend', 'file')
        ->method('addBackend', 'syslog'),
```

Note that using `DI\object()->methodParameter()` to override a specific parameter value will only override it for the first method call.