### PR TITLE
New DI\decorate() helper to decorate a previously defined entry using a callable

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -21,6 +21,16 @@ Improvements:
     ```
 - [#235](https://github.com/mnapoli/PHP-DI/issues/235) `DI\link()` is now deprecated in favor of `DI\get()`. There is no BC break as `DI\link()` still works.
 - [#193](https://github.com/mnapoli/PHP-DI/issues/193) `DI\object()->method()` now supports calling the same method twice (or more).
+- [#248](https://github.com/mnapoli/PHP-DI/issues/248): New `DI\decorate()` function to decorate a previously defined entry:
+
+    ```php
+    // file A.php
+    ProductDaoInterface::class => DI\get(ProductDaoDatabase::class)
+    // file B.php
+    ProductDaoInterface::class => DI\decorate(function ($previous, ContainerInterface $c) {
+        return new ProductDaoCached($previous, $c->get('cache.backend'));
+    })
+    ```
 
 BC breaks:
 

--- a/doc/definition.md
+++ b/doc/definition.md
@@ -226,6 +226,11 @@ return [
         return new SomeOtherClass();
     })->scope(Scope::PROTOTYPE()),
 
+    // You can decorate an entry previously defined in another file
+    'WebserviceApi' => DI\decorate(function ($previous, ContainerInterface $c) {
+        return new CachedApi($previous, $c->get('cache'));
+    }),
+
     // Defining an alias to another entry
     'some.entry' => DI\get('some.other.entry'),
 

--- a/src/DI/Definition/DecoratorDefinition.php
+++ b/src/DI/Definition/DecoratorDefinition.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition;
+
+/**
+ * Factory that decorates a sub-definition.
+ *
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class DecoratorDefinition extends FactoryDefinition implements Definition, HasSubDefinition
+{
+    /**
+     * @var Definition
+     */
+    private $decorated;
+
+    /**
+     * @return string
+     */
+    public function getSubDefinitionName()
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @param Definition $definition
+     */
+    public function setSubDefinition(Definition $definition)
+    {
+        $this->decorated = $definition;
+    }
+
+    /**
+     * @return Definition
+     */
+    public function getDecoratedDefinition()
+    {
+        return $this->decorated;
+    }
+}

--- a/src/DI/Definition/Dumper/DecoratorDefinitionDumper.php
+++ b/src/DI/Definition/Dumper/DecoratorDefinitionDumper.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition\Dumper;
+
+use DI\Definition\DecoratorDefinition;
+use DI\Definition\Definition;
+
+/**
+ * Dumps decorator definitions.
+ *
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class DecoratorDefinitionDumper implements DefinitionDumper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function dump(Definition $definition)
+    {
+        if (! $definition instanceof DecoratorDefinition) {
+            throw new \InvalidArgumentException(sprintf(
+                'This definition dumper is only compatible with DecoratorDefinition objects, %s given',
+                get_class($definition)
+            ));
+        }
+
+        return 'Decorate(' . $definition->getSubDefinitionName() . ')';
+    }
+}

--- a/src/DI/Definition/Dumper/DefinitionDumperDispatcher.php
+++ b/src/DI/Definition/Dumper/DefinitionDumperDispatcher.php
@@ -22,16 +22,13 @@ class DefinitionDumperDispatcher implements DefinitionDumper
     /**
      * Definition dumpers, indexed by the class of the definition they can dump.
      *
-     * @var DefinitionDumper[]
+     * @var DefinitionDumper[]|null
      */
     private $dumpers = array();
 
-    public function __construct($registerDefaultDumpers = true)
+    public function __construct($dumpers = null)
     {
-        // TODO lazy initialization
-        if ($registerDefaultDumpers) {
-            $this->registerDefaultDumpers();
-        }
+        $this->dumpers = $dumpers;
     }
 
     /**
@@ -39,6 +36,8 @@ class DefinitionDumperDispatcher implements DefinitionDumper
      */
     public function dump(Definition $definition)
     {
+        $this->initialize();
+
         $class = get_class($definition);
 
         if (! array_key_exists($class, $this->dumpers)) {
@@ -53,21 +52,18 @@ class DefinitionDumperDispatcher implements DefinitionDumper
         return $dumper->dump($definition);
     }
 
-    public function registerDumper($definitionClass, DefinitionDumper $dumper)
+    private function initialize()
     {
-        $this->dumpers[$definitionClass] = $dumper;
-    }
-
-    public function registerDefaultDumpers()
-    {
-        $this->dumpers = array(
-            'DI\Definition\ValueDefinition'               => new ValueDefinitionDumper(),
-            'DI\Definition\FactoryDefinition'             => new FactoryDefinitionDumper(),
-            'DI\Definition\DecoratorDefinition'           => new DecoratorDefinitionDumper(),
-            'DI\Definition\AliasDefinition'               => new AliasDefinitionDumper(),
-            'DI\Definition\ObjectDefinition'              => new ObjectDefinitionDumper(),
-            'DI\Definition\FunctionCallDefinition'        => new FunctionCallDefinitionDumper(),
-            'DI\Definition\EnvironmentVariableDefinition' => new EnvironmentVariableDefinitionDumper(),
-        );
+        if ($this->dumpers === null) {
+            $this->dumpers = array(
+                'DI\Definition\ValueDefinition'               => new ValueDefinitionDumper(),
+                'DI\Definition\FactoryDefinition'             => new FactoryDefinitionDumper(),
+                'DI\Definition\DecoratorDefinition'           => new DecoratorDefinitionDumper(),
+                'DI\Definition\AliasDefinition'               => new AliasDefinitionDumper(),
+                'DI\Definition\ObjectDefinition'              => new ObjectDefinitionDumper(),
+                'DI\Definition\FunctionCallDefinition'        => new FunctionCallDefinitionDumper(),
+                'DI\Definition\EnvironmentVariableDefinition' => new EnvironmentVariableDefinitionDumper(),
+            );
+        }
     }
 }

--- a/src/DI/Definition/Dumper/DefinitionDumperDispatcher.php
+++ b/src/DI/Definition/Dumper/DefinitionDumperDispatcher.php
@@ -28,6 +28,7 @@ class DefinitionDumperDispatcher implements DefinitionDumper
 
     public function __construct($registerDefaultDumpers = true)
     {
+        // TODO lazy initialization
         if ($registerDefaultDumpers) {
             $this->registerDefaultDumpers();
         }
@@ -62,6 +63,7 @@ class DefinitionDumperDispatcher implements DefinitionDumper
         $this->dumpers = array(
             'DI\Definition\ValueDefinition'               => new ValueDefinitionDumper(),
             'DI\Definition\FactoryDefinition'             => new FactoryDefinitionDumper(),
+            'DI\Definition\DecoratorDefinition'           => new DecoratorDefinitionDumper(),
             'DI\Definition\AliasDefinition'               => new AliasDefinitionDumper(),
             'DI\Definition\ObjectDefinition'              => new ObjectDefinitionDumper(),
             'DI\Definition\FunctionCallDefinition'        => new FunctionCallDefinitionDumper(),

--- a/src/DI/Definition/Helper/FactoryDefinitionHelper.php
+++ b/src/DI/Definition/Helper/FactoryDefinitionHelper.php
@@ -9,6 +9,7 @@
 
 namespace DI\Definition\Helper;
 
+use DI\Definition\DecoratorDefinition;
 use DI\Definition\FactoryDefinition;
 use DI\Scope;
 
@@ -30,11 +31,18 @@ class FactoryDefinitionHelper implements DefinitionHelper
     private $scope;
 
     /**
-     * @param callable $factory
+     * @var bool
      */
-    public function __construct($factory)
+    private $decorate;
+
+    /**
+     * @param callable $factory
+     * @param bool     $decorate Is the factory decorating a previous definition?
+     */
+    public function __construct($factory, $decorate = false)
     {
         $this->factory = $factory;
+        $this->decorate = $decorate;
     }
 
     /**
@@ -56,6 +64,10 @@ class FactoryDefinitionHelper implements DefinitionHelper
      */
     public function getDefinition($entryName)
     {
+        if ($this->decorate) {
+            return new DecoratorDefinition($entryName, $this->factory, $this->scope);
+        }
+
         return new FactoryDefinition($entryName, $this->factory, $this->scope);
     }
 }

--- a/src/DI/Definition/Resolver/DecoratorResolver.php
+++ b/src/DI/Definition/Resolver/DecoratorResolver.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://mnapoli.github.com/PHP-DI/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Definition\Resolver;
+
+use DI\Definition\DecoratorDefinition;
+use DI\Definition\Exception\DefinitionException;
+use DI\Definition\Definition;
+use Interop\Container\ContainerInterface;
+
+/**
+ * Resolves a decorator definition to a value.
+ *
+ * @since 5.0
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class DecoratorResolver implements DefinitionResolver
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var DefinitionResolver
+     */
+    private $definitionResolver;
+
+    /**
+     * The resolver needs a container. This container will be passed to the factory as a parameter
+     * so that the factory can access other entries of the container.
+     *
+     * @param ContainerInterface $container
+     * @param DefinitionResolver $definitionResolver Used to resolve nested definitions.
+     */
+    public function __construct(ContainerInterface $container, DefinitionResolver $definitionResolver)
+    {
+        $this->container = $container;
+        $this->definitionResolver = $definitionResolver;
+    }
+
+    /**
+     * Resolve a decorator definition to a value.
+     *
+     * This will call the callable of the definition and pass it the decorated entry.
+     *
+     * @param DecoratorDefinition $definition
+     *
+     * {@inheritdoc}
+     */
+    public function resolve(Definition $definition, array $parameters = array())
+    {
+        $this->assertIsDecoratorDefinition($definition);
+
+        $callable = $definition->getCallable();
+
+        if (! is_callable($callable)) {
+            throw new DefinitionException(sprintf(
+                'The decorator "%s" is not callable',
+                $definition->getName()
+            ));
+        }
+
+        $decoratedDefinition = $definition->getDecoratedDefinition();
+
+        if (! $decoratedDefinition instanceof Definition) {
+            throw new DefinitionException(sprintf(
+                'Entry "%s" decorates nothing: no previous definition with the same name was found',
+                $definition->getName()
+            ));
+        }
+
+        $decorated = $this->definitionResolver->resolve($decoratedDefinition);
+
+        return call_user_func($callable, $decorated, $this->container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isResolvable(Definition $definition, array $parameters = array())
+    {
+        $this->assertIsDecoratorDefinition($definition);
+
+        return true;
+    }
+
+    private function assertIsDecoratorDefinition(Definition $definition)
+    {
+        if (!$definition instanceof DecoratorDefinition) {
+            throw new \InvalidArgumentException(sprintf(
+                'This definition resolver is only compatible with DecoratorDefinition objects, %s given',
+                get_class($definition)
+            ));
+        }
+    }
+}

--- a/src/DI/Definition/Resolver/DecoratorResolver.php
+++ b/src/DI/Definition/Resolver/DecoratorResolver.php
@@ -70,6 +70,10 @@ class DecoratorResolver implements DefinitionResolver
         $decoratedDefinition = $definition->getDecoratedDefinition();
 
         if (! $decoratedDefinition instanceof Definition) {
+            if (! $definition->getSubDefinitionName()) {
+                throw new DefinitionException('Decorators cannot be nested in another definition');
+            }
+
             throw new DefinitionException(sprintf(
                 'Entry "%s" decorates nothing: no previous definition with the same name was found',
                 $definition->getName()

--- a/src/DI/Definition/Resolver/ResolverDispatcher.php
+++ b/src/DI/Definition/Resolver/ResolverDispatcher.php
@@ -45,6 +45,7 @@ class ResolverDispatcher implements DefinitionResolver
             'DI\Definition\ArrayDefinition'               => $arrayDefinitionResolver,
             'DI\Definition\ArrayDefinitionExtension'      => $arrayDefinitionResolver,
             'DI\Definition\FactoryDefinition'             => new FactoryResolver($container),
+            'DI\Definition\DecoratorDefinition'           => new DecoratorResolver($container, $resolver),
             'DI\Definition\AliasDefinition'               => new AliasResolver($container),
             'DI\Definition\ObjectDefinition'              => new ObjectCreator($resolver, $proxyFactory),
             'DI\Definition\InstanceDefinition'            => new InstanceInjector($resolver, $proxyFactory),

--- a/src/DI/functions.php
+++ b/src/DI/functions.php
@@ -61,6 +61,27 @@ if (! function_exists('DI\factory')) {
     }
 }
 
+if (! function_exists('DI\decorate')) {
+    /**
+     * Decorate the previous definition using a callable.
+     *
+     * Example:
+     *
+     *     'foo' => decorate(function ($foo, $container) {
+     *         return new CachedFoo($foo, $container->get('cache'));
+     *     })
+     *
+     * @param callable $callable The callable takes the decorated object as first parameter and
+     *                           the container as second.
+     *
+     * @return FactoryDefinitionHelper
+     */
+    function decorate($callable)
+    {
+        return new FactoryDefinitionHelper($callable, true);
+    }
+}
+
 if (! function_exists('DI\get')) {
     /**
      * Helper for referencing another container entry in an object definition.

--- a/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
@@ -124,4 +124,22 @@ class DecoratorDefinitionTest extends \PHPUnit_Framework_TestCase
         $container = $builder->build();
         $container->get('foo');
     }
+
+    /**
+     * @expectedException \DI\DependencyException
+     * @expectedExceptionMessage Error while resolving foo[0]. Decorators cannot be nested in another definition
+     */
+    public function test_decorator_in_array()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => array(
+                \DI\decorate(function ($previous) {
+                    return $previous;
+                }),
+            ),
+        ));
+        $container = $builder->build();
+        $container->get('foo');
+    }
 }

--- a/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/DecoratorDefinitionTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\IntegrationTest\Definitions;
+
+use DI\ContainerBuilder;
+use Interop\Container\ContainerInterface;
+
+/**
+ * Test decorator definitions
+ *
+ * @coversNothing
+ */
+class DecoratorDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_decorate_value()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => 'bar',
+        ));
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous) {
+                return $previous . 'baz';
+            }),
+        ));
+        $container = $builder->build();
+
+        $this->assertEquals('barbaz', $container->get('foo'));
+    }
+
+    public function test_decorate_factory()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => function () {
+                return 'bar';
+            },
+        ));
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous) {
+                return $previous . 'baz';
+            }),
+        ));
+        $container = $builder->build();
+
+        $this->assertEquals('barbaz', $container->get('foo'));
+    }
+
+    public function test_decorate_object()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => \DI\object('stdClass'),
+        ));
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous) {
+                $previous->foo = 'bar';
+                return $previous;
+            }),
+        ));
+        $container = $builder->build();
+
+        $object = $container->get('foo');
+        $this->assertEquals('bar', $object->foo);
+    }
+
+    public function test_decorator_gets_container()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => 'hello ',
+            'bar' => 'world',
+        ));
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous, ContainerInterface $container) {
+                return $previous . $container->get('bar');
+            }),
+        ));
+        $container = $builder->build();
+
+        $this->assertEquals('hello world', $container->get('foo'));
+    }
+
+    public function test_multiple_decorators()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => 'bar',
+        ));
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous) {
+                return $previous . 'baz';
+            }),
+        ));
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous) {
+                return $previous . 'bam';
+            }),
+        ));
+        $container = $builder->build();
+
+        $this->assertEquals('barbazbam', $container->get('foo'));
+    }
+
+    /**
+     * @expectedException \DI\Definition\Exception\DefinitionException
+     * @expectedExceptionMessage Entry "foo" decorates nothing: no previous definition with the same name was found
+     */
+    public function test_decorate_must_have_previous_definition()
+    {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(array(
+            'foo' => \DI\decorate(function ($previous) {
+                return $previous;
+            }),
+        ));
+        $container = $builder->build();
+        $container->get('foo');
+    }
+}

--- a/tests/UnitTest/Definition/DecoratorDefinitionTest.php
+++ b/tests/UnitTest/Definition/DecoratorDefinitionTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition;
+
+use DI\Definition\DecoratorDefinition;
+use DI\Definition\ValueDefinition;
+use DI\Scope;
+
+/**
+ * @covers \DI\Definition\DecoratorDefinition
+ */
+class DecoratorDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_getters()
+    {
+        $callable = function () {
+        };
+        $definition = new DecoratorDefinition('foo', $callable);
+
+        $this->assertEquals('foo', $definition->getName());
+        $this->assertEquals($callable, $definition->getCallable());
+        // Default scope
+        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+    }
+
+    /**
+     * @test
+     */
+    public function should_accept_callables_other_than_closures()
+    {
+        $callable = array($this, 'foo');
+        $definition = new DecoratorDefinition('foo', $callable);
+
+        $this->assertEquals('foo', $definition->getName());
+        $this->assertEquals($callable, $definition->getCallable());
+    }
+
+    /**
+     * @test
+     */
+    public function should_not_be_cacheable()
+    {
+        $definition = new DecoratorDefinition('foo', function () {
+        });
+        $this->assertNotInstanceOf('DI\Definition\CacheableDefinition', $definition);
+    }
+
+    /**
+     * @test
+     */
+    public function should_extend_previous_definition()
+    {
+        $definition = new DecoratorDefinition('foo', function () {
+        });
+        $this->assertInstanceOf('DI\Definition\HasSubDefinition', $definition);
+        $this->assertEquals($definition->getName(), $definition->getSubDefinitionName());
+
+        $subDefinition = new ValueDefinition('foo', 'bar');
+        $definition->setSubDefinition($subDefinition);
+        $this->assertSame($subDefinition, $definition->getDecoratedDefinition());
+    }
+}

--- a/tests/UnitTest/Definition/Dumper/DecoratorDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/DecoratorDefinitionDumperTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition\Dumper;
+
+use DI\Definition\DecoratorDefinition;
+use DI\Definition\Dumper\DecoratorDefinitionDumper;
+use DI\Definition\ValueDefinition;
+
+/**
+ * @covers \DI\Definition\Dumper\DecoratorDefinitionDumper
+ */
+class DecoratorDefinitionDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDump()
+    {
+        $definition = new DecoratorDefinition('foo', 'bar');
+        $dumper = new DecoratorDefinitionDumper();
+
+        $this->assertEquals('Decorate(foo)', $dumper->dump($definition));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage This definition dumper is only compatible with DecoratorDefinition objects, DI\Definition\ValueDefinition given
+     */
+    public function testInvalidDefinitionType()
+    {
+        $definition = new ValueDefinition('foo', 'bar');
+        $dumper = new DecoratorDefinitionDumper();
+
+        $dumper->dump($definition);
+    }
+}

--- a/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
+++ b/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
@@ -10,6 +10,8 @@
 namespace DI\Test\UnitTest\Definition\Dumper;
 
 use DI\Definition\AliasDefinition;
+use DI\Definition\DecoratorDefinition;
+use DI\Definition\Dumper\DecoratorDefinitionDumper;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\Dumper\AliasDefinitionDumper;
 use DI\Definition\Dumper\ObjectDefinitionDumper;
@@ -86,6 +88,20 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
 
         $factoryDumper = new FactoryDefinitionDumper();
         $this->assertEquals($factoryDumper->dump($definition), $dumper->dump($definition));
+    }
+
+    /**
+     * @test
+     */
+    public function should_dump_decorator_definitions_by_default()
+    {
+        $dumper = new DefinitionDumperDispatcher();
+        $dumper->registerDefaultDumpers();
+
+        $definition = new DecoratorDefinition('foo', 'strlen');
+
+        $decoratorDumper = new DecoratorDefinitionDumper();
+        $this->assertEquals($decoratorDumper->dump($definition), $dumper->dump($definition));
     }
 
     /**

--- a/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
+++ b/tests/UnitTest/Definition/Dumper/DefinitionDumperDispatcherTest.php
@@ -42,8 +42,9 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
             ->with($definition)
             ->will($this->returnValue('foo'));
 
-        $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDumper(get_class($definition), $subDumper);
+        $dumper = new DefinitionDumperDispatcher(array(
+            get_class($definition) => $subDumper
+        ));
 
         $this->assertEquals('foo', $dumper->dump($definition));
     }
@@ -54,7 +55,6 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
     public function should_dump_value_definitions_by_default()
     {
         $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDefaultDumpers();
 
         $definition = new ValueDefinition('foo', 'bar');
 
@@ -68,7 +68,6 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
     public function should_dump_alias_definitions_by_default()
     {
         $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDefaultDumpers();
 
         $definition = new AliasDefinition('foo', 'bar');
 
@@ -82,7 +81,6 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
     public function should_dump_factory_definitions_by_default()
     {
         $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDefaultDumpers();
 
         $definition = new FactoryDefinition('foo', 'strlen');
 
@@ -96,7 +94,6 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
     public function should_dump_decorator_definitions_by_default()
     {
         $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDefaultDumpers();
 
         $definition = new DecoratorDefinition('foo', 'strlen');
 
@@ -110,7 +107,6 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
     public function should_dump_class_definitions_by_default()
     {
         $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDefaultDumpers();
 
         $definition = new ObjectDefinition('foo', 'MyClass');
 
@@ -124,7 +120,6 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
     public function should_dump_env_variables_definitions_by_default()
     {
         $dumper = new DefinitionDumperDispatcher();
-        $dumper->registerDefaultDumpers();
 
         $definition = new EnvironmentVariableDefinition('foo', 'bar');
 
@@ -139,7 +134,7 @@ class DefinitionDumperDispatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function should_only_accept_definitions_it_can_dump()
     {
-        $dumper = new DefinitionDumperDispatcher(false);
+        $dumper = new DefinitionDumperDispatcher(array());
         $dumper->dump(new ValueDefinition('foo', 'bar'));
     }
 }

--- a/tests/UnitTest/Definition/FactoryDefinitionTest.php
+++ b/tests/UnitTest/Definition/FactoryDefinitionTest.php
@@ -59,7 +59,6 @@ class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new FactoryDefinition('foo', function () {
         });
-
         $this->assertNotInstanceOf('DI\Definition\CacheableDefinition', $definition);
     }
 }

--- a/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
@@ -9,6 +9,7 @@
 
 namespace DI\Test\UnitTest\Definition\Helper;
 
+use DI\Definition\DecoratorDefinition;
 use DI\Definition\FactoryDefinition;
 use DI\Definition\Helper\FactoryDefinitionHelper;
 use DI\Scope;
@@ -18,7 +19,10 @@ use DI\Scope;
  */
 class FactoryDefinitionHelperTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetDefinition()
+    /**
+     * @test
+     */
+    public function creates_factory_definition()
     {
         $callable = function () {
         };
@@ -32,7 +36,25 @@ class FactoryDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($callable, $definition->getCallable());
     }
 
-    public function testDefaultScope()
+    /**
+     * @test
+     */
+    public function creates_decorator_definition()
+    {
+        $callable = function () {
+        };
+        $helper = new FactoryDefinitionHelper($callable, true);
+        $definition = $helper->getDefinition('foo');
+
+        $this->assertTrue($definition instanceof DecoratorDefinition);
+        $this->assertSame('foo', $definition->getName());
+        $this->assertSame($callable, $definition->getCallable());
+    }
+
+    /**
+     * @test
+     */
+    public function is_singleton_by_default()
     {
         $callable = function () {
         };

--- a/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
+++ b/tests/UnitTest/Definition/Resolver/DecoratorResolverTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * PHP-DI
+ *
+ * @link      http://php-di.org/
+ * @copyright Matthieu Napoli (http://mnapoli.fr/)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace DI\Test\UnitTest\Definition\Resolver;
+
+use DI\Definition\DecoratorDefinition;
+use DI\Definition\FactoryDefinition;
+use DI\Definition\Resolver\DecoratorResolver;
+use DI\Definition\Resolver\DefinitionResolver;
+use DI\Definition\ValueDefinition;
+use EasyMock\EasyMock;
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * @covers \DI\Definition\Resolver\DecoratorResolver
+ */
+class DecoratorResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DecoratorResolver
+     */
+    private $resolver;
+
+    /**
+     * @var DefinitionResolver|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $parentResolver;
+
+    public function setUp()
+    {
+        $container = EasyMock::mock('Interop\Container\ContainerInterface');
+        $this->parentResolver = EasyMock::mock('DI\Definition\Resolver\DefinitionResolver');
+        $this->resolver = new DecoratorResolver($container, $this->parentResolver);
+    }
+
+    public function provideCallables()
+    {
+        return array(
+            'closure'        => array(function () { return 'bar'; }),
+            'string'         => array(__NAMESPACE__ . '\FactoryDefinitionResolver_test'),
+            'array'          => array(array(new FactoryDefinitionResolverTestClass(), 'foo')),
+            'invokableClass' => array(new FactoryDefinitionResolverCallableClass()),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function should_resolve_decorators()
+    {
+        $previousDefinition = new ValueDefinition('foo', 'bar');
+
+        $callable = function ($previous, ContainerInterface $container) {
+            return $previous . 'baz';
+        };
+        $definition = new DecoratorDefinition('foo', $callable);
+        $definition->setSubDefinition($previousDefinition);
+
+        $this->parentResolver->expects($this->once())
+            ->method('resolve')
+            ->with($previousDefinition)
+            ->will($this->returnValue($previousDefinition->getValue()));
+
+        $value = $this->resolver->resolve($definition);
+
+        $this->assertEquals('barbaz', $value);
+    }
+
+    /**
+     * @test
+     * @expectedException \DI\Definition\Exception\DefinitionException
+     * @expectedExceptionMessage The decorator "foo" is not callable
+     */
+    public function should_throw_if_the_factory_is_not_callable()
+    {
+        $definition = new DecoratorDefinition('foo', 'Hello world');
+
+        $this->resolver->resolve($definition);
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage This definition resolver is only compatible with DecoratorDefinition objects, DI\Definition\ValueDefinition given
+     */
+    public function should_only_resolve_decorator_definitions()
+    {
+        $definition = new ValueDefinition('foo', 'bar');
+
+        $this->resolver->resolve($definition);
+    }
+}

--- a/tests/UnitTest/FunctionsTest.php
+++ b/tests/UnitTest/FunctionsTest.php
@@ -57,12 +57,30 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
      */
     public function test_factory()
     {
-        $definition = \DI\factory(function () {
+        $helper = \DI\factory(function () {
             return 42;
         });
 
-        $this->assertInstanceOf('DI\Definition\Helper\FactoryDefinitionHelper', $definition);
-        $callable = $definition->getDefinition('entry')->getCallable();
+        $this->assertInstanceOf('DI\Definition\Helper\FactoryDefinitionHelper', $helper);
+        $definition = $helper->getDefinition('entry');
+        $this->assertInstanceOf('DI\Definition\FactoryDefinition', $definition);
+        $callable = $definition->getCallable();
+        $this->assertEquals(42, $callable());
+    }
+
+    /**
+     * @covers ::\DI\decorate
+     */
+    public function test_decorate()
+    {
+        $helper = \DI\decorate(function () {
+            return 42;
+        });
+
+        $this->assertInstanceOf('DI\Definition\Helper\FactoryDefinitionHelper', $helper);
+        $definition = $helper->getDefinition('entry');
+        $this->assertInstanceOf('DI\Definition\DecoratorDefinition', $definition);
+        $callable = $definition->getCallable();
         $this->assertEquals(42, $callable());
     }
 


### PR DESCRIPTION
Fixes #248

New `DI\decorate()` helper to decorate a previously defined entry using a callable:

```php
    // file A.php
    ProductDaoInterface::class => DI\get(ProductDaoDatabase::class)
```

```php
    // file B.php
    ProductDaoInterface::class => DI\decorate(function ($previous, ContainerInterface $c) {
        return new ProductDaoCached($previous, $c->get('cache.backend'));
    })
```

In this example we decorate the database DAO with a cache.