### PR TITLE
Simpler scopes: one less Composer dependency and better performances

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -4,7 +4,7 @@
 
 Improvements:
 
-- Lighter package: requires 4 less Composer dependencies by default
+- Lighter package: requires 5 less Composer dependencies by default
 - [#207](https://github.com/mnapoli/PHP-DI/issues/207): Support for `DI\link()` in arrays
 - [#208](https://github.com/mnapoli/PHP-DI/issues/208): Support for nested definitions
 - [#226](https://github.com/mnapoli/PHP-DI/pull/226): `DI\factory()` can now be omitted with closures:
@@ -42,6 +42,7 @@ BC breaks:
 Internal changes in case you were replacing/extending some parts:
 
 - the definition sources architecture has been refactored, if you defined custom definition sources you will need to update your code (it should be much easier now)
+- `DI\Scope` internal implementation has changed. You are encouraged to use the constants (`DI\Scope::SINGLETON` and `DI\Scope::PROTOTYPE`) instead of the static methods, but backward compatibility is kept (static methods still work).
 
 ## 4.4
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "doctrine/annotations": "~1.2",
         "doctrine/cache": "~1.0",
         "mnapoli/phpdocreader": "~1.3",
-        "myclabs/php-enum": "~1.1",
         "container-interop/container-interop": "~1.0"
     },
     "require-dev": {

--- a/doc/definition.md
+++ b/doc/definition.md
@@ -194,7 +194,7 @@ return [
         ->constructor(DI\get('db.host'), DI\get('My\OtherClass')),
 
     'My\OtherClass' => DI\object()
-        ->scope(Scope::PROTOTYPE())
+        ->scope(Scope::PROTOTYPE)
         ->constructor(DI\get('db.host'), DI\get('db.port'))
         ->method('setFoo2', DI\get('My\Foo1'), DI\get('My\Foo2'))
         ->property('bar', 'My\Bar'),
@@ -224,7 +224,7 @@ return [
     // The prototype scope will return a new object each time we request SomeOtherClass
     'SomeOtherClass' => DI\factory(function () {
         return new SomeOtherClass();
-    })->scope(Scope::PROTOTYPE()),
+    })->scope(Scope::PROTOTYPE),
 
     // You can decorate an entry previously defined in another file
     'WebserviceApi' => DI\decorate(function ($previous, ContainerInterface $c) {

--- a/doc/migration/5.0.md
+++ b/doc/migration/5.0.md
@@ -50,6 +50,30 @@ If you defined a closure as a value (e.g. to have the closure injected in a clas
     }),
 ```
 
+### Scopes
+
+The internal implementation of scopes has been simplified: this results in one less Composer dependency and better performances. Backward compatibility is kept so you don't have to change anything, however if you want you can replace the use of static methods (which might be deprecated in the future) with the constants.
+
+Before:
+
+```php
+return [
+    'MyClass' => DI\object()
+        ->scope(Scope::PROTOTYPE()), // static method
+];
+```
+
+After:
+
+```php
+return [
+    'MyClass' => DI\object()
+        ->scope(Scope::PROTOTYPE), // constant
+];
+```
+
+Again, this change is optional, the static methods still work.
+
 ## Lazy injection
 
 The [ProxyManager](https://github.com/Ocramius/ProxyManager) package comes with a lot of dependencies and is only useful only for lazy injection. This package is not installed by default in v5.0 in order to lighten PHP-DI's dependencies.

--- a/doc/scopes.md
+++ b/doc/scopes.md
@@ -40,6 +40,6 @@ You can specify the scope by using the `scope` method on the helper:
 
 return [
     'MyService' => DI\object()
-        ->scope(Scope::PROTOTYPE()),
+        ->scope(Scope::PROTOTYPE),
 ];
 ```

--- a/src/DI/Annotation/Injectable.php
+++ b/src/DI/Annotation/Injectable.php
@@ -10,6 +10,7 @@
 namespace DI\Annotation;
 
 use DI\Scope;
+use UnexpectedValueException;
 
 /**
  * "Injectable" annotation
@@ -26,7 +27,7 @@ final class Injectable
 {
     /**
      * The scope of an class: prototype, singleton
-     * @var Scope|null
+     * @var string|null
      */
     private $scope;
 
@@ -42,7 +43,13 @@ final class Injectable
     public function __construct(array $values)
     {
         if (isset($values['scope'])) {
-            $this->scope = new Scope($values['scope']);
+            if ($values['scope'] === 'prototype') {
+                $this->scope = Scope::PROTOTYPE;
+            } elseif ($values['scope'] === 'singleton') {
+                $this->scope = Scope::SINGLETON;
+            } else {
+                throw new UnexpectedValueException(sprintf("Value '%s' is not a valid scope", $values['scope']));
+            }
         }
         if (isset($values['lazy'])) {
             $this->lazy = (boolean) $values['lazy'];
@@ -50,7 +57,7 @@ final class Injectable
     }
 
     /**
-     * @return Scope|null
+     * @return string|null
      */
     public function getScope()
     {

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -119,7 +119,7 @@ class Container implements ContainerInterface, FactoryInterface, InvokerInterfac
         $value = $this->resolveDefinition($definition);
 
         // If the entry is singleton, we store it to always return it without recomputing it
-        if ($definition->getScope() == Scope::SINGLETON()) {
+        if ($definition->getScope() === Scope::SINGLETON) {
             $this->singletonEntries[$name] = $value;
         }
 

--- a/src/DI/Definition/AbstractFunctionCallDefinition.php
+++ b/src/DI/Definition/AbstractFunctionCallDefinition.php
@@ -77,6 +77,6 @@ abstract class AbstractFunctionCallDefinition implements Definition
      */
     public function getScope()
     {
-        return Scope::PROTOTYPE();
+        return Scope::PROTOTYPE;
     }
 }

--- a/src/DI/Definition/AliasDefinition.php
+++ b/src/DI/Definition/AliasDefinition.php
@@ -53,7 +53,7 @@ class AliasDefinition implements CacheableDefinition
      */
     public function getScope()
     {
-        return Scope::PROTOTYPE();
+        return Scope::PROTOTYPE;
     }
 
     /**

--- a/src/DI/Definition/ArrayDefinition.php
+++ b/src/DI/Definition/ArrayDefinition.php
@@ -53,7 +53,7 @@ class ArrayDefinition implements Definition
      */
     public function getScope()
     {
-        return Scope::SINGLETON();
+        return Scope::SINGLETON;
     }
 
     /**

--- a/src/DI/Definition/Definition.php
+++ b/src/DI/Definition/Definition.php
@@ -9,8 +9,6 @@
 
 namespace DI\Definition;
 
-use DI\Scope;
-
 /**
  * Definition
  *
@@ -28,7 +26,7 @@ interface Definition
     /**
      * Returns the scope of the entry
      *
-     * @return Scope
+     * @return string
      */
     public function getScope();
 }

--- a/src/DI/Definition/EnvironmentVariableDefinition.php
+++ b/src/DI/Definition/EnvironmentVariableDefinition.php
@@ -48,7 +48,7 @@ class EnvironmentVariableDefinition implements CacheableDefinition
     private $defaultValue;
 
     /**
-     * @var Scope|null
+     * @var string|null
      */
     private $scope;
 
@@ -99,18 +99,18 @@ class EnvironmentVariableDefinition implements CacheableDefinition
     }
 
     /**
-     * @param Scope $scope
+     * @param string $scope
      */
-    public function setScope(Scope $scope)
+    public function setScope($scope)
     {
         $this->scope = $scope;
     }
 
     /**
-     * @return Scope
+     * {@inheritdoc}
      */
     public function getScope()
     {
-        return $this->scope ?: Scope::SINGLETON();
+        return $this->scope ?: Scope::SINGLETON;
     }
 }

--- a/src/DI/Definition/FactoryDefinition.php
+++ b/src/DI/Definition/FactoryDefinition.php
@@ -25,7 +25,7 @@ class FactoryDefinition implements Definition
     private $name;
 
     /**
-     * @var Scope
+     * @var string
      */
     private $scope;
 
@@ -36,11 +36,11 @@ class FactoryDefinition implements Definition
     private $factory;
 
     /**
-     * @param string     $name    Entry name
-     * @param callable   $factory Callable that returns the value associated to the entry name.
-     * @param Scope|null $scope
+     * @param string      $name    Entry name
+     * @param callable    $factory Callable that returns the value associated to the entry name.
+     * @param string|null $scope
      */
-    public function __construct($name, $factory, Scope $scope = null)
+    public function __construct($name, $factory, $scope = null)
     {
         $this->name = $name;
         $this->factory = $factory;
@@ -62,7 +62,7 @@ class FactoryDefinition implements Definition
      */
     public function getScope()
     {
-        return $this->scope ?: Scope::SINGLETON();
+        return $this->scope ?: Scope::SINGLETON;
     }
 
     /**

--- a/src/DI/Definition/Helper/FactoryDefinitionHelper.php
+++ b/src/DI/Definition/Helper/FactoryDefinitionHelper.php
@@ -11,7 +11,6 @@ namespace DI\Definition\Helper;
 
 use DI\Definition\DecoratorDefinition;
 use DI\Definition\FactoryDefinition;
-use DI\Scope;
 
 /**
  * Helps defining how to create an instance of a class using a factory (callable).
@@ -26,7 +25,7 @@ class FactoryDefinitionHelper implements DefinitionHelper
     private $factory;
 
     /**
-     * @var Scope|null
+     * @var string|null
      */
     private $scope;
 
@@ -48,11 +47,11 @@ class FactoryDefinitionHelper implements DefinitionHelper
     /**
      * Defines the scope of the entry.
      *
-     * @param Scope $scope
+     * @param string $scope
      *
      * @return FactoryDefinitionHelper
      */
-    public function scope(Scope $scope)
+    public function scope($scope)
     {
         $this->scope = $scope;
         return $this;

--- a/src/DI/Definition/Helper/ObjectDefinitionHelper.php
+++ b/src/DI/Definition/Helper/ObjectDefinitionHelper.php
@@ -12,7 +12,6 @@ namespace DI\Definition\Helper;
 use DI\Definition\ObjectDefinition;
 use DI\Definition\ObjectDefinition\MethodInjection;
 use DI\Definition\ObjectDefinition\PropertyInjection;
-use DI\Scope;
 
 /**
  * Helps defining how to create an instance of a class.
@@ -32,7 +31,7 @@ class ObjectDefinitionHelper implements DefinitionHelper
     private $lazy;
 
     /**
-     * @var Scope|null
+     * @var string|null
      */
     private $scope;
 
@@ -81,11 +80,11 @@ class ObjectDefinitionHelper implements DefinitionHelper
     /**
      * Defines the scope of the entry.
      *
-     * @param Scope $scope
+     * @param string $scope
      *
      * @return ObjectDefinitionHelper
      */
-    public function scope(Scope $scope)
+    public function scope($scope)
     {
         $this->scope = $scope;
         return $this;

--- a/src/DI/Definition/InstanceDefinition.php
+++ b/src/DI/Definition/InstanceDefinition.php
@@ -55,7 +55,7 @@ class InstanceDefinition implements Definition
      */
     public function getScope()
     {
-        return Scope::PROTOTYPE();
+        return Scope::PROTOTYPE;
     }
 
     /**

--- a/src/DI/Definition/ObjectDefinition.php
+++ b/src/DI/Definition/ObjectDefinition.php
@@ -52,7 +52,7 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
     private $methodInjections = array();
 
     /**
-     * @var Scope|null
+     * @var string|null
      */
     private $scope;
 
@@ -165,19 +165,19 @@ class ObjectDefinition implements Definition, CacheableDefinition, HasSubDefinit
     }
 
     /**
-     * @param Scope $scope
+     * @param string $scope
      */
-    public function setScope(Scope $scope)
+    public function setScope($scope)
     {
         $this->scope = $scope;
     }
 
     /**
-     * @return Scope
+     * {@inheritdoc}
      */
     public function getScope()
     {
-        return $this->scope ?: Scope::SINGLETON();
+        return $this->scope ?: Scope::SINGLETON;
     }
 
     /**

--- a/src/DI/Definition/StringDefinition.php
+++ b/src/DI/Definition/StringDefinition.php
@@ -53,7 +53,7 @@ class StringDefinition implements Definition
      */
     public function getScope()
     {
-        return Scope::SINGLETON();
+        return Scope::SINGLETON;
     }
 
     /**

--- a/src/DI/Definition/ValueDefinition.php
+++ b/src/DI/Definition/ValueDefinition.php
@@ -54,7 +54,7 @@ class ValueDefinition implements Definition
      */
     public function getScope()
     {
-        return Scope::SINGLETON();
+        return Scope::SINGLETON;
     }
 
     /**

--- a/src/DI/Scope.php
+++ b/src/DI/Scope.php
@@ -9,8 +9,6 @@
 
 namespace DI;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Scope enum.
  *
@@ -18,30 +16,39 @@ use MyCLabs\Enum\Enum;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class Scope extends Enum
+class Scope
 {
-    const SINGLETON = 'singleton';
-    const PROTOTYPE = 'prototype';
-
     /**
      * A singleton entry will be computed once and shared.
-     * For a class, only a single instance of the class will be created.
      *
-     * @return Scope
+     * For a class, only a single instance of the class will be created.
      */
-    public static function SINGLETON()
-    {
-        return new static(self::SINGLETON);
-    }
+    const SINGLETON = 'singleton';
 
     /**
      * A prototype entry will be recomputed each time it is asked.
-     * For a class, this will create a new instance each time.
      *
-     * @return Scope
+     * For a class, this will create a new instance each time.
+     */
+    const PROTOTYPE = 'prototype';
+
+    /**
+     * Method kept for backward compatibility, use the constant instead.
+     *
+     * @return string
+     */
+    public static function SINGLETON()
+    {
+        return self::SINGLETON;
+    }
+
+    /**
+     * Method kept for backward compatibility, use the constant instead.
+     *
+     * @return string
      */
     public static function PROTOTYPE()
     {
-        return new static(self::PROTOTYPE);
+        return self::PROTOTYPE;
     }
 }

--- a/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
+++ b/tests/IntegrationTest/Definitions/ArrayDefinitionTest.php
@@ -46,7 +46,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
             ),
             'singleton' => \DI\object('stdClass'),
             'prototype' => \DI\object('stdClass')
-                ->scope(Scope::PROTOTYPE()),
+                ->scope(Scope::PROTOTYPE),
         ));
         $container = $builder->build();
 
@@ -90,7 +90,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
                 \DI\get('prototype'),
             ),
             'prototype' => \DI\object('stdClass')
-                ->scope(Scope::PROTOTYPE()),
+                ->scope(Scope::PROTOTYPE),
         ));
         $container = $builder->build();
 

--- a/tests/IntegrationTest/Fixtures/definitions.php
+++ b/tests/IntegrationTest/Fixtures/definitions.php
@@ -6,7 +6,7 @@ return array(
     'foo' => 'bar',
 
     'DI\Test\IntegrationTest\Fixtures\Class1' => DI\object()
-            ->scope(Scope::PROTOTYPE())
+            ->scope(Scope::PROTOTYPE)
             ->property('property1', DI\get('DI\Test\IntegrationTest\Fixtures\Class2'))
             ->property('property2', DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
             ->property('property3', DI\get('namedDependency'))
@@ -29,7 +29,7 @@ return array(
     'DI\Test\IntegrationTest\Fixtures\Implementation1' => DI\object(),
 
     'DI\Test\IntegrationTest\Fixtures\Interface1' => DI\object('DI\Test\IntegrationTest\Fixtures\Implementation1')
-            ->scope(Scope::SINGLETON()),
+            ->scope(Scope::SINGLETON),
     'DI\Test\IntegrationTest\Fixtures\Interface2' => DI\object('DI\Test\IntegrationTest\Fixtures\Class3'),
 
     'namedDependency' => DI\object('DI\Test\IntegrationTest\Fixtures\Class2'),

--- a/tests/IntegrationTest/InjectionTest.php
+++ b/tests/IntegrationTest/InjectionTest.php
@@ -81,7 +81,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
         $containerPHP->set(
             'DI\Test\IntegrationTest\Fixtures\Class1',
             \DI\object()
-                ->scope(Scope::PROTOTYPE())
+                ->scope(Scope::PROTOTYPE)
                 ->property('property1', \DI\get('DI\Test\IntegrationTest\Fixtures\Class2'))
                 ->property('property2', \DI\get('DI\Test\IntegrationTest\Fixtures\Interface1'))
                 ->property('property3', \DI\get('namedDependency'))
@@ -104,7 +104,7 @@ class InjectionTest extends \PHPUnit_Framework_TestCase
         $containerPHP->set(
             'DI\Test\IntegrationTest\Fixtures\Interface1',
             \DI\object('DI\Test\IntegrationTest\Fixtures\Implementation1')
-                ->scope(Scope::SINGLETON())
+                ->scope(Scope::SINGLETON)
         );
         $containerPHP->set('namedDependency', \DI\object('DI\Test\IntegrationTest\Fixtures\Class2'));
         $containerPHP->set('DI\Test\IntegrationTest\Fixtures\LazyDependency', \DI\object()->lazy());

--- a/tests/UnitTest/Annotation/InjectableTest.php
+++ b/tests/UnitTest/Annotation/InjectableTest.php
@@ -11,6 +11,7 @@ namespace DI\Test\UnitTest\Annotation;
 
 use DI\Annotation\Injectable;
 use DI\Definition\Source\AnnotationReader;
+use DI\Scope;
 use Doctrine\Common\Annotations\AnnotationReader as DoctrineAnnotationReader;
 use ReflectionClass;
 
@@ -61,7 +62,7 @@ class InjectableTest extends \PHPUnit_Framework_TestCase
         $annotation = $this->annotationReader->getClassAnnotation($class, 'DI\Annotation\Injectable');
 
         $this->assertInstanceOf('DI\Annotation\Injectable', $annotation);
-        $this->assertEquals('singleton', $annotation->getScope());
+        $this->assertEquals(Scope::SINGLETON, $annotation->getScope());
         $this->assertNull($annotation->isLazy());
     }
 }

--- a/tests/UnitTest/ContainerGetTest.php
+++ b/tests/UnitTest/ContainerGetTest.php
@@ -81,7 +81,7 @@ class ContainerGetTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \DI\Definition\Exception\DefinitionException
-     * @expectedExceptionMessage Error while reading @Injectable on DI\Test\UnitTest\Fixtures\InvalidScope: Value 'foobar' is not part of the enum DI\Scope
+     * @expectedExceptionMessage Error while reading @Injectable on DI\Test\UnitTest\Fixtures\InvalidScope: Value 'foobar' is not a valid scope
      * @coversNothing
      */
     public function testGetWithInvalidScope()

--- a/tests/UnitTest/ContainerMakeTest.php
+++ b/tests/UnitTest/ContainerMakeTest.php
@@ -69,7 +69,7 @@ class ContainerMakeTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \DI\Definition\Exception\DefinitionException
-     * @expectedExceptionMessage Error while reading @Injectable on DI\Test\UnitTest\Fixtures\InvalidScope: Value 'foobar' is not part of the enum DI\Scope
+     * @expectedExceptionMessage Error while reading @Injectable on DI\Test\UnitTest\Fixtures\InvalidScope: Value 'foobar' is not a valid scope
      * @coversNothing
      */
     public function testMakeWithInvalidScope()

--- a/tests/UnitTest/Definition/AbstractFunctionCallDefinitionTest.php
+++ b/tests/UnitTest/Definition/AbstractFunctionCallDefinitionTest.php
@@ -24,7 +24,7 @@ class AbstractFunctionCallDefinitionTest extends \PHPUnit_Framework_TestCase
         $definition = $this->getMockForAbstractClass('DI\Definition\AbstractFunctionCallDefinition');
 
         $this->assertNull($definition->getName());
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
         $this->assertEmpty($definition->getParameters());
     }
 

--- a/tests/UnitTest/Definition/AliasDefinitionTest.php
+++ b/tests/UnitTest/Definition/AliasDefinitionTest.php
@@ -44,7 +44,7 @@ class AliasDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new AliasDefinition('foo', 'bar');
 
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/ArrayDefinitionExtensionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionExtensionTest.php
@@ -38,7 +38,7 @@ class ArrayDefinitionExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new ArrayDefinitionExtension('foo', array());
 
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/ArrayDefinitionTest.php
+++ b/tests/UnitTest/Definition/ArrayDefinitionTest.php
@@ -35,7 +35,7 @@ class ArrayDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new ArrayDefinition('foo', array());
 
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/DecoratorDefinitionTest.php
+++ b/tests/UnitTest/Definition/DecoratorDefinitionTest.php
@@ -27,7 +27,7 @@ class DecoratorDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $definition->getName());
         $this->assertEquals($callable, $definition->getCallable());
         // Default scope
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
+++ b/tests/UnitTest/Definition/Dumper/ObjectDefinitionDumperTest.php
@@ -95,7 +95,7 @@ class ObjectDefinitionDumperTest extends \PHPUnit_Framework_TestCase
     public function testScopePrototype()
     {
         $definition = \DI\object('stdClass')
-            ->scope(Scope::PROTOTYPE())
+            ->scope(Scope::PROTOTYPE)
             ->getDefinition('foo');
         $resolver = new ObjectDefinitionDumper();
 

--- a/tests/UnitTest/Definition/EnvironmentVariableDefinitionTest.php
+++ b/tests/UnitTest/Definition/EnvironmentVariableDefinitionTest.php
@@ -34,7 +34,7 @@ class EnvironmentVariableDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new EnvironmentVariableDefinition('foo', 'bar');
 
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/FactoryDefinitionTest.php
+++ b/tests/UnitTest/Definition/FactoryDefinitionTest.php
@@ -26,7 +26,7 @@ class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $definition->getName());
         $this->assertEquals($callable, $definition->getCallable());
         // Default scope
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**
@@ -47,9 +47,9 @@ class FactoryDefinitionTest extends \PHPUnit_Framework_TestCase
     public function can_have_a_custom_scope()
     {
         $definition = new FactoryDefinition('foo', function () {
-        }, Scope::PROTOTYPE());
+        }, Scope::PROTOTYPE);
 
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/FactoryDefinitionHelperTest.php
@@ -27,12 +27,12 @@ class FactoryDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $callable = function () {
         };
         $helper = new FactoryDefinitionHelper($callable);
-        $helper->scope(Scope::PROTOTYPE());
+        $helper->scope(Scope::PROTOTYPE);
         $definition = $helper->getDefinition('foo');
 
         $this->assertTrue($definition instanceof FactoryDefinition);
         $this->assertSame('foo', $definition->getName());
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
         $this->assertSame($callable, $definition->getCallable());
     }
 
@@ -61,6 +61,6 @@ class FactoryDefinitionHelperTest extends \PHPUnit_Framework_TestCase
         $helper = new FactoryDefinitionHelper($callable);
         $definition = $helper->getDefinition('foo');
 
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 }

--- a/tests/UnitTest/Definition/Helper/ObjectDefinitionHelperTest.php
+++ b/tests/UnitTest/Definition/Helper/ObjectDefinitionHelperTest.php
@@ -28,7 +28,7 @@ class ObjectDefinitionHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', $definition->getName());
         $this->assertEquals('foo', $definition->getClassName());
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
         $this->assertNull($definition->getConstructorInjection());
         $this->assertEmpty($definition->getPropertyInjections());
         $this->assertEmpty($definition->getMethodInjections());
@@ -52,10 +52,10 @@ class ObjectDefinitionHelperTest extends \PHPUnit_Framework_TestCase
     public function allows_to_define_the_scope()
     {
         $helper = new ObjectDefinitionHelper();
-        $helper->scope(Scope::PROTOTYPE());
+        $helper->scope(Scope::PROTOTYPE);
         $definition = $helper->getDefinition('foo');
 
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/InstanceDefinitionTest.php
+++ b/tests/UnitTest/Definition/InstanceDefinitionTest.php
@@ -51,6 +51,6 @@ class InstanceDefinitionTest extends \PHPUnit_Framework_TestCase
         $instance = new \stdClass();
         $definition = new InstanceDefinition($instance, EasyMock::mock('DI\Definition\ObjectDefinition'));
 
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
     }
 }

--- a/tests/UnitTest/Definition/ObjectDefinitionTest.php
+++ b/tests/UnitTest/Definition/ObjectDefinitionTest.php
@@ -24,12 +24,12 @@ class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new ObjectDefinition('foo', 'bar');
         $definition->setLazy(true);
-        $definition->setScope(Scope::PROTOTYPE());
+        $definition->setScope(Scope::PROTOTYPE);
 
         $this->assertEquals('foo', $definition->getName());
         $this->assertEquals('bar', $definition->getClassName());
         $this->assertTrue($definition->isLazy());
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
 
         $definition->setClassName('classname');
         $this->assertEquals('classname', $definition->getClassName());
@@ -42,7 +42,7 @@ class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $definition->getName());
         $this->assertEquals('foo', $definition->getClassName());
         $this->assertFalse($definition->isLazy());
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
         $this->assertNull($definition->getConstructorInjection());
         $this->assertEmpty($definition->getPropertyInjections());
         $this->assertEmpty($definition->getMethodInjections());
@@ -77,7 +77,7 @@ class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
 
         $subDefinition = new ObjectDefinition('bar');
         $subDefinition->setLazy(true);
-        $subDefinition->setScope(Scope::PROTOTYPE());
+        $subDefinition->setScope(Scope::PROTOTYPE);
         $subDefinition->setConstructorInjection(MethodInjection::constructor());
         $subDefinition->addPropertyInjection(new PropertyInjection('property1', 'Property1'));
         $subDefinition->addPropertyInjection(new PropertyInjection('property3', 'Property3'));
@@ -89,7 +89,7 @@ class ObjectDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $definition->getName());
         $this->assertEquals('bar', $definition->getClassName());
         $this->assertTrue($definition->isLazy());
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
         $this->assertNotNull($definition->getConstructorInjection());
         $this->assertCount(3, $definition->getPropertyInjections());
         $this->assertCount(3, $definition->getMethodInjections());

--- a/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
+++ b/tests/UnitTest/Definition/Source/AnnotationReaderTest.php
@@ -194,7 +194,7 @@ class AnnotationReaderTest extends \PHPUnit_Framework_TestCase
         $definition = $source->getDefinition('DI\Test\UnitTest\Definition\Source\Fixtures\AnnotationInjectableFixture');
         $this->assertInstanceOf('DI\Definition\Definition', $definition);
 
-        $this->assertEquals(Scope::PROTOTYPE(), $definition->getScope());
+        $this->assertEquals(Scope::PROTOTYPE, $definition->getScope());
         $this->assertTrue($definition->isLazy());
     }
 

--- a/tests/UnitTest/Definition/StringDefinitionTest.php
+++ b/tests/UnitTest/Definition/StringDefinitionTest.php
@@ -32,7 +32,7 @@ class StringDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new StringDefinition('foo', 'bar');
 
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Definition/ValueDefinitionTest.php
+++ b/tests/UnitTest/Definition/ValueDefinitionTest.php
@@ -32,7 +32,7 @@ class ValueDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $definition = new ValueDefinition('foo', 1);
 
-        $this->assertEquals(Scope::SINGLETON(), $definition->getScope());
+        $this->assertEquals(Scope::SINGLETON, $definition->getScope());
     }
 
     /**

--- a/tests/UnitTest/Fixtures/InvalidScope.php
+++ b/tests/UnitTest/Fixtures/InvalidScope.php
@@ -18,5 +18,4 @@ use DI\Annotation\Injectable;
  */
 class InvalidScope
 {
-
 }

--- a/tests/UnitTest/ScopeTest.php
+++ b/tests/UnitTest/ScopeTest.php
@@ -21,8 +21,7 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
      */
     public function should_provide_prototype_scope()
     {
-        $scope = Scope::PROTOTYPE();
-        $this->assertEquals('prototype', $scope->getValue());
+        $this->assertEquals(Scope::PROTOTYPE, Scope::PROTOTYPE());
     }
 
     /**
@@ -30,7 +29,6 @@ class ScopeTest extends \PHPUnit_Framework_TestCase
      */
     public function should_provide_singleton_scope()
     {
-        $scope = Scope::SINGLETON();
-        $this->assertEquals('singleton', $scope->getValue());
+        $this->assertEquals(Scope::SINGLETON, Scope::SINGLETON());
     }
 }


### PR DESCRIPTION
The internal implementation of scopes has been simplified: this results in one less Composer dependency and better performances. Backward compatibility is kept (static methods still work).

Before:

```php
return [
    'MyClass' => DI\object()
        ->scope(Scope::PROTOTYPE()), // static method
];
```

After:

```php
return [
    'MyClass' => DI\object()
        ->scope(Scope::PROTOTYPE), // constant
];
```

This is more inline with PSR-1/PSR-2, more natural (the concept of enum was a bit forced here) and more efficient.