### PR TITLE
Less composer dependencies (Doctrine)

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -7,7 +7,7 @@ This is the complete change log. You can also read the [migration guide](doc/mig
 Improvements:
 
 - New [Silex integration](doc/frameworks/silex.md)
-- Lighter package: requires 4 less Composer dependencies by default
+- Lighter package: from 10 to 3 Composer dependencies!
 - [#235](https://github.com/mnapoli/PHP-DI/issues/235): `DI\link()` is now deprecated in favor of `DI\get()`. There is no BC break as `DI\link()` still works.
 - [#207](https://github.com/mnapoli/PHP-DI/issues/207): Support for `DI\link()` in arrays
 - [#203](https://github.com/mnapoli/PHP-DI/issues/203): New `DI\string()` helper ([documentation](doc/php-definitions.md))
@@ -31,8 +31,10 @@ Improvements:
 BC breaks:
 
 - PHP-DI now requires a version of PHP >= 5.4.0
-- [#251](https://github.com/mnapoli/PHP-DI/issues/251): Annotations are disabled by default, if you use annotations enable them with `$containerBuilder->useAnnotations(true)`.
-- [#198](https://github.com/mnapoli/PHP-DI/issues/198): `ocramius/proxy-manager` is not installed by default anymore, you need to require it in `composer.json` (`~1.0`) if you want to use **lazy injection**
+- The package is lighter by default:
+    - [#251](https://github.com/mnapoli/PHP-DI/issues/251): Annotations are disabled by default, if you use annotations enable them with `$containerBuilder->useAnnotations(true)`. Additionally the `doctrine/annotations` package isn't required by default anymore, so you also need to run `composer require doctrine/annotations`.
+    - `doctrine/cache` is not installed by default anymore, you need to require it in `composer.json` (`~1.0`) if you want to configure a cache for PHP-DI
+    - [#198](https://github.com/mnapoli/PHP-DI/issues/198): `ocramius/proxy-manager` is not installed by default anymore, you need to require it in `composer.json` (`~1.0`) if you want to use **lazy injection**
 - Closures are now converted into factory definitions automatically. If you ever defined a closure as a value (e.g. to have the closure injected in a class), you need to wrap the closure with the new `DI\value()` helper.
 - [#223](https://github.com/mnapoli/PHP-DI/issues/223): `DI\ContainerInterface` was deprecated since v4.1 and has been removed
 

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,20 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "doctrine/annotations": "~1.2",
-        "doctrine/cache": "~1.0",
-        "mnapoli/phpdocreader": "~1.3",
         "container-interop/container-interop": "~1.0",
-        "php-di/invoker": "~1.0"
+        "php-di/invoker": "~1.0",
+        "php-di/phpdoc-reader": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "mnapoli/phpunit-easymock": "~0.1.4",
+        "doctrine/cache": "~1.0",
+        "doctrine/annotations": "~1.2",
         "ocramius/proxy-manager": "~1.0"
     },
     "suggest": {
+        "doctrine/cache": "Install it if you want to use the cache (version ~1.0)",
+        "doctrine/annotations": "Install it if you want to use annotations (version ~1.2)",
         "ocramius/proxy-manager": "Install it if you want to use lazy injection (version ~1.0)"
     },
     "extra": {

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -4,7 +4,18 @@ layout: documentation
 
 # Annotations
 
-Annotations **are disabled by default**. You need to [configure the `ContainerBuilder`](container-configuration.md) to use them:
+Annotations **are disabled by default**. To be able to use them, you first need to install the [Doctrine Annotations](http://doctrine-common.readthedocs.org/en/latest/reference/annotations.html) library using Composer:
+
+```json
+{
+    "require": {
+        ...
+        "doctrine/annotations": "~1.2"
+    }
+}
+```
+
+Then you need to [configure the `ContainerBuilder`](container-configuration.md) to use them:
 
 ```php
 $containerBuilder->useAnnotations(true);

--- a/doc/migration/5.0.md
+++ b/doc/migration/5.0.md
@@ -29,6 +29,12 @@ $builder->useAnnotations(true);
 $container = $builder->build();
 ```
 
+And install the Composer dependency by running:
+
+```
+composer require doctrine/annotations
+```
+
 ### DI\link()
 
 The `DI\link()` function helper has been deprecated (but still works). The reason for this is that when importing the function in PHP 5.6 with `use function DI\link`, it conflicts with [PHP's native `link()` function](http://php.net/link). This was a silly oversight when designing PHP-DI 4, sorry about that :)
@@ -125,6 +131,16 @@ composer require "ocramius/proxy-manager:~1.0"
 Read more in [#198](https://github.com/mnapoli/PHP-DI/issues/198) or in the [Lazy Injection documentation](../lazy-injection.md).
 
 ## Caching
+
+### Caching library
+
+The `doctrine/cache` library isn't required by PHP-DI by default anymore (in order to make the package lighter). If you set up a cache for PHP-DI, you need to require it:
+
+```
+composer require doctrine/cache
+```
+
+### Caching and dynamic definitions
 
 *Note: this section might look complicated and confusing to you: it concerns a change for an edgy use case and you probably don't have to worry about this*.
 

--- a/doc/performances.md
+++ b/doc/performances.md
@@ -8,16 +8,28 @@ layout: documentation
 
 PHP-DI uses the [definitions](definition.md) you configured to instantiate classes.
 
-Reading those definitions (and, if enabled, reading annotations or autowiring) on each request can be avoided by using a cache. The caching system PHP-DI uses is the Doctrine Cache library.
+Reading those definitions (and, if enabled, reading annotations or autowiring) on each request can be avoided by using a cache. The caching system PHP-DI uses is the [Doctrine Cache](http://doctrine-common.readthedocs.org/en/latest/reference/caching.html) library.
 
 ### Setup
+
+The Doctrine Cache library is not installed by default with PHP-DI, you need to install it with Composer:
+
+```json
+{
+    "require": {
+        ...
+        "doctrine/cache": "~1.0"
+    }
+}
+```
+
+Then you can then pass a cache instance to the container builder:
 
 ```php
 $containerBuilder->setDefinitionCache(new Doctrine\Common\Cache\ApcCache());
 ```
 
-Heads up: do not use a cache in a development environment, else changes you make to the definitions (annotations, configuration files, etc.) may not be taken into account.
-The only cache you might use in development is the `ArrayCache` because it doesn't persist data between requests.
+Heads up: do not use a cache in a development environment, else changes you make to the definitions (annotations, configuration files, etc.) may not be taken into account. The only cache you might use in development is the `ArrayCache` because it doesn't persist data between requests.
 
 ### Cache types
 

--- a/news/15-php-di-5-0-released.md
+++ b/news/15-php-di-5-0-released.md
@@ -12,7 +12,7 @@ This is a new major version that comes with:
 - minor backward compatibility breaks (nothing to get too alarmed about)
 - API and syntax simplifications (aka syntactic sugar)
 - new major features for modular applications (aka bundles, modules, plugins, …)
-- performance improvements (thanks [Blackfire](https://blackfire.io/)) and a lighter package
+- performance improvements (thanks [Blackfire](https://blackfire.io/)) and a much lighter package (from 10 to 3 Composer dependencies, less files, …)
 - a new website, logo and half rewritten documentation
 - Silex integration
 


### PR DESCRIPTION
Doctrine annotations and cache are now optional dependencies for a lighter default package. Also requires the new `php-di/phpdoc-reader` package that replaces `mnapoli/phpdocreader`.

Migrating from 4.x to 5.0 requires users to install `doctrine/annotations` or `doctrine/cache` if they need to use it.

With this last change, PHP-DI 5 has only 3 Composer dependencies (v4 has 10)!